### PR TITLE
NPE during InputStreamReader initialization

### DIFF
--- a/src/main/java/com/github/javafaker/Faker.java
+++ b/src/main/java/com/github/javafaker/Faker.java
@@ -38,7 +38,7 @@ public class Faker {
     public Faker(Locale locale) {
         logger.info("Using default locale " + locale);
         String languageCode = locale.getLanguage();
-        Map valuesMap = (Map) Yaml.load(ClassLoader.getSystemResourceAsStream(languageCode + ".yml"));
+        Map valuesMap = (Map) Yaml.load(getClass().getClassLoader().getResourceAsStream(languageCode + ".yml"));
         valuesMap = (Map) valuesMap.get(languageCode);
         fakeValuesMap = (Map<String, Object>) valuesMap.get("faker");
     }


### PR DESCRIPTION
I used this code in my servlet

``` java
    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
        Faker faker = new Faker();
        List<Person> persons = new ArrayList<Person>();
        for (int i=1; i <=20; i++){
            Person aPerson = new Employee();
            aPerson.setName(faker.name());
            aPerson.setEmail(faker.firstName()+"@email.com");
            aPerson.setPhone(faker.phoneNumber());
            persons.add(aPerson);
            System.out.println(aPerson);
        }
        request.setAttribute("people", persons);

        RequestDispatcher rd = request.getRequestDispatcher("pages/list_persons.jsp");
        rd.forward(request, response);
    }
```

And I got error on application server

``` java
java.lang.NullPointerException
    java.io.Reader.<init>(Unknown Source)
    java.io.InputStreamReader.<init>(Unknown Source)
    org.ho.yaml.YamlDecoder.<init>(Unknown Source)
    org.ho.yaml.YamlConfig.load(Unknown Source)
    org.ho.yaml.Yaml.load(Unknown Source)
    com.github.javafaker.Faker.<init>(Faker.java:41)
    com.github.javafaker.Faker.<init>(Faker.java:35)
    org.sbelei.ListOfPersons.doGet(ListOfPersons.java:33)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:621)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:722)
```

In this pull request is solution that I use to read stream on any application server.

Signed-off-by: Sergiy Beley sergiy.beley@gmail.com
