### PR TITLE
fixed #bothify to work as expected

### DIFF
--- a/src/main/java/com/github/javafaker/Faker.java
+++ b/src/main/java/com/github/javafaker/Faker.java
@@ -270,7 +270,7 @@ public class Faker {
                 char c = source.charAt(i);
                 for (CharacterTransformer t : transformers) {
                     if (t.triggerCharacter() == c) {
-                        sb.append((char) (97 + RandomUtils.nextInt(26))); // a-z
+                        sb.append(t.transform(c));
                         break charLoop;
                     }
                 }


### PR DESCRIPTION
Looks like the intent of #bothify was to transform both ? into a random letter and # into a random digit, but it was instead just calling #letterify.  

Instead of two loops over the characters in the string (such that if I called both methods), I built it out a bit so it will iterate the characters once.  
