### PR TITLE
url and email tests fail with first/last names that have quotation marks and accents

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -28,9 +28,9 @@ public class Internet {
         return join(new Object[]{
                 "www",
                 ".",
-                name.firstName().toLowerCase(),
+                name.firstName().toLowerCase().replaceAll("'", ""),
                 "-",
-                name.lastName().toLowerCase(),
+                name.lastName().toLowerCase().replaceAll("'", ""),
                 ".",
                 fakeValuesService.fetchString("internet.domain_suffix")
         });

--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -20,7 +20,7 @@ public class Internet {
                 ".",
                 name.lastName().toLowerCase(),
                 "@",
-                fakeValuesService.fetchString("internet.free_email")
+                java.net.IDN.toASCII(fakeValuesService.fetchString("internet.free_email"))
         });
     }
     
@@ -28,9 +28,11 @@ public class Internet {
         return join(new Object[]{
                 "www",
                 ".",
-                name.firstName().toLowerCase().replaceAll("'", ""),
-                "-",
-                name.lastName().toLowerCase().replaceAll("'", ""),
+                java.net.IDN.toASCII(
+                    name.firstName().toLowerCase().replaceAll("'", "") +
+                    "-" +
+                    name.lastName().toLowerCase().replaceAll("'", "")
+                ),
                 ".",
                 fakeValuesService.fetchString("internet.domain_suffix")
         });


### PR DESCRIPTION
some of the test data contains first and last names with quotation marks and non-ASCII accented characters