### PR TITLE
Add a (single) word method to the Lorem generator.

### DIFF
--- a/src/main/java/com/github/javafaker/Lorem.java
+++ b/src/main/java/com/github/javafaker/Lorem.java
@@ -34,6 +34,11 @@ public class Lorem {
         return words(3);
     }
 
+    public String word() {
+        List<String> words = (List<String>) fakeValuesService.fetchObject("lorem.words");
+        return words.get(randomService.nextInt(words.size()));
+    }
+
     public String sentence(int wordCount) {
         return capitalize(join(words(wordCount + randomService.nextInt(6)), " ") + ".");
     }

--- a/src/test/java/com/github/javafaker/LoremTest.java
+++ b/src/test/java/com/github/javafaker/LoremTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class LoremTest {
 
@@ -22,4 +23,8 @@ public class LoremTest {
         assertEquals(0, faker.lorem().fixedString(-1).length());
     }
 
+    @Test
+    public void wordShouldNotBeNull() {
+        assertNotNull(faker.lorem().word());
+    }
 }


### PR DESCRIPTION
I found myself repeatedly requesting a list containing one word and then getting it from its List. This skips the creation of the List to begin with, allowing clearer test code when only one word is desired. 