### PR TITLE
add Lorem#character and Lorem#characters

### DIFF
--- a/src/main/java/com/github/javafaker/Lorem.java
+++ b/src/main/java/com/github/javafaker/Lorem.java
@@ -12,6 +12,19 @@ import static org.apache.commons.lang.StringUtils.join;
 
 public class Lorem {
 
+    static {
+        StringBuilder builder = new StringBuilder(36);
+        for (char number = '0'; number <= '9'; number++) {
+            builder.append(number);
+        }
+        for (char character = 'a'; character <= 'z'; character++) {
+            builder.append(character);
+        }
+        characters = builder.toString().toCharArray();
+    }
+
+    private static final char[] characters;
+
     private final FakeValuesServiceInterface fakeValuesService;
     private final RandomService randomService;
 
@@ -20,7 +33,26 @@ public class Lorem {
         this.randomService = randomService;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    public char character() {
+        return characters(1).charAt(0);
+    }
+
+    public String characters() {
+        return characters(255);
+    }
+
+    public String characters(int fixedNumberOfCharacters) {
+        if (fixedNumberOfCharacters < 1) {
+            return "";
+        }
+        char[] buffer = new char[fixedNumberOfCharacters];
+        for (int i = 0; i < buffer.length; i++) {
+            buffer[i] = characters[randomService.nextInt(characters.length)];
+        }
+        return new String(buffer);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public List<String> words(int num) {
         List<String> returnList = new ArrayList();
         for (int i = 0; i < num; i++) {

--- a/src/test/java/com/github/javafaker/BeerTest.java
+++ b/src/test/java/com/github/javafaker/BeerTest.java
@@ -27,7 +27,7 @@ public class BeerTest {
 
     @Test
     public void testHop() {
-        assertThat(faker.beer().hop(), matchesRegularExpression("[A-Za-z'() 0-9-]+"));
+        assertThat(faker.beer().hop(), matchesRegularExpression("[A-Za-z'()\\. 0-9-]+"));
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/LoremTest.java
+++ b/src/test/java/com/github/javafaker/LoremTest.java
@@ -1,10 +1,14 @@
 package com.github.javafaker;
 
+import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class LoremTest {
 
@@ -24,7 +28,25 @@ public class LoremTest {
     }
 
     @Test
-    public void wordShouldNotBeNull() {
-        assertNotNull(faker.lorem().word());
+    public void wordShouldNotBeNullOrEmpty() {
+        assertThat(faker.lorem().word(), not(isEmptyOrNullString()));
+    }
+
+    @Test
+    public void testCharacter() {
+        assertThat(String.valueOf(faker.lorem().character()), matchesRegularExpression("[a-z\\d]{1}"));
+    }
+
+    @Test
+    public void testCharacters() {
+        assertThat(faker.lorem().characters(), matchesRegularExpression("[a-z\\d]{255}"));
+    }
+
+    @Test
+    public void testCharactersWithLength() {
+        assertThat(faker.lorem().characters(2), matchesRegularExpression("[a-z\\d]{2}"));
+        assertThat(faker.lorem().characters(500), matchesRegularExpression("[a-z\\d]{500}"));
+        assertThat(faker.lorem().characters(0), isEmptyString());
+        assertThat(faker.lorem().characters(-1), isEmptyString());
     }
 }

--- a/src/test/java/com/github/javafaker/NameTest.java
+++ b/src/test/java/com/github/javafaker/NameTest.java
@@ -17,17 +17,17 @@ public class NameTest {
 
     @Test
     public void testName() {
-        assertThat(faker.name().name(), matchesRegularExpression("(\\w+\\.?( )?){2,3}"));
+        assertThat(faker.name().name(), matchesRegularExpression("([\\w']+\\.?( )?){2,3}"));
     }
 
     @Test
     public void testNameWithMiddle() {
-        assertThat(faker.name().nameWithMiddle(), matchesRegularExpression("(\\w+\\.?( )?){3,4}"));
+        assertThat(faker.name().nameWithMiddle(), matchesRegularExpression("([\\w']+\\.?( )?){3,4}"));
     }
 
     @Test
     public void testFullName() {
-        assertThat(faker.name().fullName(), matchesRegularExpression("(\\w+\\.?( )?){2,4}"));
+        assertThat(faker.name().fullName(), matchesRegularExpression("([\\w']+\\.?( )?){2,4}"));
     }
 
     @Test


### PR DESCRIPTION
Some notes:

* There is some overlap with `Lorem#fixedString`.
* I modeled the method closely on the ruby faker one, so lower-case alphanumeric characters are returned. Not sure this is the best approach.
* Not sure if `character` should return a `String` instead of a `char`?
* I would have liked to use the much less verbose `new BigInteger(int, random).toString(32)` to generate the string. This was not possible because  `JVMRandom` throws an `UnsupportedOperationException` when `#nextBytes` is invoked by the `BigInteger` constructor.

 

