### PR TITLE
changed snakeyaml to the bmoliveira one to provide support for android

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
     <dependencies>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -46,9 +52,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.17</version>
+            <groupId>com.github.bmoliveira</groupId>
+            <artifactId>snake-yaml</artifactId>
+            <version>v1.18-android</version>
         </dependency>
         <dependency>
             <groupId>com.github.mifmif</groupId>
@@ -142,5 +148,27 @@
                 </plugin>
 			</plugins>
 		</pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>com.github.bmoliveira:snake-yaml</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 	</build>
 </project>


### PR DESCRIPTION
use maven shade plugin to include this dependency in the java-faker jar, because it is not available from maven central

I tried to add the shade plugin configuration to the `<plugin-management>` section (like the other plugin configuration), but that did not work. I guess it's because the shade plugin is not bound to maven life-cycle by default. (Not sure why the other plugins are in the `<plugin-management>` section, because usually this section is used to configure project builds that inherit from the project.)

By the way: I was able to successfully use java-faker on an android emulator. :)