### PR TITLE
Remove single quotes from names used in email addresses

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -24,9 +24,9 @@ public class Internet {
 
     public String emailAddress() {
         return emailAddress(join(new Object[]{
-                name.firstName().toLowerCase(),
+                name.firstName().toLowerCase().replaceAll("'", ""),
                 ".",
-                name.lastName().toLowerCase()
+                name.lastName().toLowerCase().replaceAll("'", "")
         }));
     }
 


### PR DESCRIPTION
Currently, given certain names that can show up (for example, O'Reilly), if a name has a single quote in it, it'll generate an invalid email address. This removes any single quotes that may be in the name.