### PR TITLE
Handle legacy-style constructed Locales

### DIFF
--- a/src/test/java/com/github/javafaker/integration/FakerIT.java
+++ b/src/test/java/com/github/javafaker/integration/FakerIT.java
@@ -10,21 +10,14 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Locale;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.reflections.ReflectionUtils.getAllMethods;
-import static org.reflections.ReflectionUtils.withModifier;
-import static org.reflections.ReflectionUtils.withParametersCount;
-import static org.reflections.ReflectionUtils.withReturnType;
+import static org.reflections.ReflectionUtils.*;
 
 /**
  * The purpose of these tests is to ensure that the Locales have been properly configured
@@ -53,6 +46,7 @@ public class FakerIT {
     @Parameterized.Parameters(name = "testing locale {0} and random {1}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][]{
+                {Locale.US, null},
                 {Locale.ENGLISH, null},
                 {Locale.FRENCH, null},
                 {Locale.CANADA_FRENCH, null},
@@ -60,6 +54,11 @@ public class FakerIT {
                 {new Locale("pt"), null},
                 {FINNISH_LOCALE, null},
                 {Locale.ENGLISH, new Random()},
+                {new Locale("pt-BR"), null},
+                {new Locale("pt-br"), null},
+                {new Locale("Pt_br"), null},
+                {new Locale("pT_Br"), null},
+                {new Locale("pt","Br","x2"), null},
                 {null, new Random()},
                 {null, null}};
         return Arrays.asList(data);

--- a/src/test/java/com/github/javafaker/integration/MostSpecificLocaleIT.java
+++ b/src/test/java/com/github/javafaker/integration/MostSpecificLocaleIT.java
@@ -1,0 +1,40 @@
+package com.github.javafaker.integration;
+
+import com.github.javafaker.service.FakeValuesService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * The purpose of these tests is to ensure that the Locales have been properly configured
+ * and that methods return values. The unit tests should ensure what the values returned
+ * are correct. These tests just ensure that the methods can be invoked.
+ */
+public class MostSpecificLocaleIT {
+
+    private FakeValuesService en;
+    private FakeValuesService en_US;
+
+    @Before
+    public void setupFakers() {
+        en = new FakeValuesService(new Locale("en"), null);
+        en_US = new FakeValuesService(new Locale("en","US"), null);
+    }
+
+    @Test
+    public void resolvesTheMostSpecificLocale() {
+        
+        final List<String> enDefaultCountries = (List<String>) en.fetchObject("address.default_country");
+        final List<String> enUsDefaultCountries = (List<String>) en_US.fetchObject("address.default_country");
+        
+        assertThat(enDefaultCountries, hasSize(1));
+        assertThat(enUsDefaultCountries, hasSize(3));
+        
+        assertThat("the default country for en is not en_US", enDefaultCountries, is(not(enUsDefaultCountries)));
+    }
+}


### PR DESCRIPTION
Closes DiUS/java-faker#125

Fixes a couple of issues.
1) when constructing a new locale like new Locale("pt-br"), the correct file /pt-BR.yml will be loaded.
2) the correct yaml file is returned by language and country code.  loading a new Faker with en_US would return /en.yml and not /en-US.yml