### PR TITLE
Create unshaded jar and shaded jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,19 +153,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.3</version>
-                <configuration>
-                    <artifactSet>
-                        <includes>
-                            <include>com.github.bmoliveira:snake-yaml</include>
-                        </includes>
-                    </artifactSet>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>deps</shadedClassifierName>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.github.bmoliveira:snake-yaml</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Generally speaking, the main artifact for a library should NOT include dependencies.  This can cause
issues in larger projects where the shaded classes may cause duplicate classes.

A better option is to publish an unshaded jar by default and add another jar identified by a classifier like 'deps'.

This change does just that.  If a user wants the dependencies by default then <classifier>deps</classifier> can
be added to the maven POM.