### PR TITLE
Add arguments to YML directives

### DIFF
--- a/src/main/java/com/github/javafaker/Faker.java
+++ b/src/main/java/com/github/javafaker/Faker.java
@@ -284,4 +284,23 @@ public class Faker {
     public String resolve(String key) {
         return this.fakeValuesService.resolve(key, this, this);
     }
+
+    /**
+     * Allows the evaluation of native YML expressions to allow you to build your own.
+     *
+     * The following are valid expressions: 
+     * <ul>
+     *     <li>#{regexify '(a|b){2,3}'}</li>
+     *     <li>#{regexify '\\.\\*\\?\\+'}</li>
+     *     <li>#{bothify '????','false'}</li>
+     *     <li>#{Name.first_name} #{Name.first_name} #{Name.last_name}</li>
+     *     <li>#{number.number_between '1','10'}</li>
+     * </ul>
+     * @param expression (see examples above)
+     * @return the evaluated string expression
+     * @throws RuntimeException if unable to evaluate the expression
+     */
+    public String expression(String expression) {
+        return this.fakeValuesService.expression(expression, this);
+    }
 }

--- a/src/test/java/com/github/javafaker/AbstractFakerTest.java
+++ b/src/test/java/com/github/javafaker/AbstractFakerTest.java
@@ -1,13 +1,29 @@
 package com.github.javafaker;
 
 import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 public class AbstractFakerTest {
+    @Spy
     protected Faker faker;
 
     @Before
     public void before() {
-        faker = new Faker();
+        MockitoAnnotations.initMocks(this);
+
+        
+        Logger rootLogger = LogManager.getLogManager().getLogger("");
+        Handler[] handlers = rootLogger.getHandlers();
+        rootLogger.setLevel(Level.FINEST);
+        for (Handler h : handlers) {
+            h.setLevel(Level.FINEST);
+        }
     }
 
 }

--- a/src/test/java/com/github/javafaker/FakerTest.java
+++ b/src/test/java/com/github/javafaker/FakerTest.java
@@ -1,6 +1,5 @@
 package com.github.javafaker;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Random;
@@ -10,13 +9,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class FakerTest extends AbstractFakerTest {
-
-    private Faker faker;
-
-    @Before
-    public void before() {
-        faker = new Faker();
-    }
 
     @Test
     public void bothifyShouldGenerateLettersAndNumbers() {
@@ -111,6 +103,33 @@ public class FakerTest extends AbstractFakerTest {
     @Test
     public void regexifyShouldGenerateEscapedCharacters() {
         assertThat(faker.regexify("\\.\\*\\?\\+"), matchesRegularExpression("\\.\\*\\?\\+"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void badExpressionTooManyArgs() {
+        faker.expression("#{regexify 'a','a'}");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void badExpressionTooFewArgs() {
+        faker.expression("#{regexify}");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void badExpressionCouldntCoerce() {
+        faker.expression("#{number.number_between 'x','10'}");
+    }
+
+    @Test
+    public void expression() {
+        assertThat(faker.expression("#{regexify '(a|b){2,3}'}"), matchesRegularExpression("(a|b){2,3}"));
+        assertThat(faker.expression("#{regexify '\\.\\*\\?\\+'}"), matchesRegularExpression("\\.\\*\\?\\+"));
+        assertThat(faker.expression("#{bothify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));
+        assertThat(faker.expression("#{bothify '????','false'}"), matchesRegularExpression("[a-z]{4}"));
+        assertThat(faker.expression("#{letterify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));
+        assertThat(faker.expression("#{Name.first_name} #{Name.first_name} #{Name.last_name}"), matchesRegularExpression("[a-zA-Z']+ [a-zA-Z']+ [a-zA-Z']+"));
+        assertThat(faker.expression("#{number.number_between '1','10'}"), matchesRegularExpression("[1-9]"));
+        assertThat(faker.expression("#{color.name}"), matchesRegularExpression("[a-z\\s]+"));
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/RandomFakerTest.java
+++ b/src/test/java/com/github/javafaker/RandomFakerTest.java
@@ -16,6 +16,7 @@ public class RandomFakerTest extends AbstractFakerTest {
 
     @Before
     public void before() {
+        super.before();
         random = new Random();
         faker = new Faker(random);
     }

--- a/src/test/java/com/github/javafaker/UniversityTest.java
+++ b/src/test/java/com/github/javafaker/UniversityTest.java
@@ -8,13 +8,6 @@ import static org.junit.Assert.assertThat;
 
 public class UniversityTest extends AbstractFakerTest {
 
-    private Faker faker;
-
-    @Before
-    public void before() {
-        faker = new Faker();
-    }
-
     @Test
     public void testName() {
         assertThat(faker.university().name(), matchesRegularExpression("[A-Za-z'() ]+"));

--- a/src/test/java/com/github/javafaker/service/RandomServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/RandomServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.javafaker.service;
 
+import com.github.javafaker.AbstractFakerTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,12 +15,13 @@ import static org.junit.Assert.assertThat;
  * @author pmiklos
  *
  */
-public class RandomServiceTest {
+public class RandomServiceTest extends AbstractFakerTest {
 
     private RandomService randomService;
 
     @Before
     public void before() {
+        super.before();
         randomService = new RandomService(new Random());
     }
 

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -5,6 +5,9 @@ test:
        simple: "hello"
        simpleResolution: "#{hello}"
        advancedResolution: "#{Superhero.name}"
+       regexify1: "#{regexify '[45]{2}'}"
+       regexify_cell: "#{regexify '4[57]9'}"
+       bothify_2: "#{bothify '??##','true'}"
        multipleResolution: "#{hello} #{Superhero.descriptor}"
        resolutionWithList:
            - "#{hello}"


### PR DESCRIPTION
resolves DiUS/java-faker#134 (closed PR)

The idea to use arguments in resolve was closely related to something i wanted to do which is to put the power of letterify, numberify and regexify into the YML expression language.  This allows for more complicated expressions that can be sculpted to be more correct without having to write java.

Now you can use something like #{regexify '[45]{2}ABC'} and it will work returning either 45ABC or 55ABC, etc...  This should help in creating more correct phone numbers, area codes, etc...

Any method exposed on Faker, even with arguments will work.

Even #{bothify '##??','true'} will work.  While all arguments are 'strings' in the YML, they are coerced to the appropriate type prior to calling the method in Faker, so this expression will result in faker.bothify("##??", true).