### PR TITLE
Fix method resolution with overloaded methods

### DIFF
--- a/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
@@ -226,12 +226,12 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
      * if the message changes, it's ok to update the test provided
      * the two conditions above are still true.
      */
-    @Test/*(expected = RuntimeException.class)*/
+    @Test
     public void expressionWithValidFakerObjectValidMethodInvalidArgs() {
         expressionShouldFailWith("#{Number.number_between 'x','y'}", 
-                "Unable to coerce x to Long via Long(String) constructor.");
+                "Can't find method on Number called numberbetween.");
     }
-
+    
     /**
      * Two things are important here:
      * 1) the message in the exception should be USEFUL


### PR DESCRIPTION
Fixes DiUS/java-faker#143

There was an intermittent test failure where the error message would say :
Expected: is "Unable to coerce x to Long via Long(String) constructor."
but: was "Unable to coerce x to Integer via Integer(String) constructor."

The issue is getMethod() returning the methods in a non-deterministic order.
Fixing this could have been easy by simply changing the check to look for Long or Integer but
this would hide a real issue where by methodName(int) called via methodName(Long.MAX_VALUE) would
die even if methodName(long) existed because it would attempt to coerce the arguments
to int ONLY and ignore the long variation.

I altered the logic to attempt to coerce the arguments at the same time the method is located
by name.  This means that methodName(Long.MAX_VALUE) will skip over methodName(int) because it would
fail and will continue to find methodName(int).