### PR TITLE
add openjdk6 to travis configuration, because java-faker should still…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
 - oraclejdk7
 - oraclejdk8
 - openjdk7
+- openjdk6
 script: "mvn verify failsafe:integration-test failsafe:verify"
 branches:
   except:


### PR DESCRIPTION
… run on java 6