### PR TITLE
Use maven shade plugin to include the com.github.bmoliveir:snake-yaml…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,25 +153,33 @@
 			</plugins>
 		</pluginManagement>
         <plugins>
+            <!-- Shade com.github.bmoliveira:snake-yaml because it is not available in maven central
+                and therefore forces (gradle) users to add https://jitpack.io as a repo. This workaround
+                is not possible for companies with strict policies regarding maven repos. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.3</version>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>com.github.bmoliveira:snake-yaml</include>
+                        </includes>
+                    </artifactSet>
+                    <!-- use package rewriting to prevent conflicts with different snakeyaml versions -->
+                    <relocations>
+                        <relocation>
+                            <pattern>org.yaml.snakeyaml</pattern>
+                            <shadedPattern>com.github.javafaker.shaded.snakeyaml</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>deps</shadedClassifierName>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.github.bmoliveira:snake-yaml</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
… dependency in the java-faker jar, because it is not available from maven central. This forces (gradle) users to add https://jitpack.io as a repo. Even this workaround is not possible for companies with strict policies regarding maven repos.

This is a improved version of #103. It use package rewriting, so there is no conflict, even if the user uses a different snakeyaml version directly.

This fixes #157 and #158.