### PR TITLE
Always return valid ISBN Numbers

### DIFF
--- a/src/main/java/com/github/javafaker/Code.java
+++ b/src/main/java/com/github/javafaker/Code.java
@@ -1,7 +1,11 @@
 package com.github.javafaker;
 
 import org.apache.commons.lang3.ArrayUtils;
+import static org.apache.commons.lang3.math.NumberUtils.toInt;
 
+/**
+ * ISBN Rules : https://en.wikipedia.org/wiki/International_Standard_Book_Number
+ */
 public class Code {
 
     private final Faker faker;
@@ -10,41 +14,133 @@ public class Code {
         this.faker = faker;
     }
 
-    public String isbn10() {
-        StringBuilder isbn10 = new StringBuilder();
-        int sum = 0;
-        for (int i = 10; i > 1; i--) {
-            int n = faker.random().nextInt(10);
-            sum += i * n;
-            isbn10.append(n);
-        }
-        int check = (11 - sum % 11) % 11;
-        isbn10.append('-');
-        isbn10.append(check != 10 ? check : "X");
-        return isbn10.toString();
+    /**
+     * This can be overridden by specifying
+     * <code>
+     *     code:
+     *       isbn_gs1: "some expression"
+     * </code>
+     * in the appropriate yml file.
+     * @return a GS1 code for an ISBN13, currently is only 978 and 979
+     */
+    public String isbnGs1() {
+        return faker.regexify("978|979");
+    }
+    /**
+     * This can be overridden by specifying
+     * <code>
+     *     code:
+     *       isbn_group: "some expression"
+     * </code>
+     * in the appropriate yml file.
+     * @return an ISBN group number
+     */
+    public String isbnGroup() {
+        return faker.regexify("[0-1]");
     }
 
-    public String isbn13() {
-        StringBuilder isbn13 = new StringBuilder();
-        int sum = 0;
-        int multiplier = 1;
-        int a = 1;
-        int b = 2;
-        for (int i = 0; i < 12; i++) {
-            int n = faker.random().nextInt(10);
-            sum += multiplier * n;
-            multiplier = multiplier == 1 ? 3 : 1;
-            isbn13.append(n);
-            if (i == b) {
-                isbn13.append('-');
-                int t = b;
-                b += a;
-                a = t;
-            }
+    /**
+     * This can be overridden by specifying
+     * <code>
+     *     code:
+     *       isbn_registrant: "some expression"
+     * </code>
+     * in the appropriate yml file.
+     * @return an ISBN registrant 'element' with separator
+     */
+    public String isbnRegistrant() {
+        int ct = faker.random().nextInt(6) + 1;
+        switch (ct) {
+            case 6:
+                return faker.number().numberBetween(0,1) + faker.number().digit() + "-" + faker.number().digits(6);
+            case 5:
+                return faker.number().numberBetween(200,699) + "-" + faker.number().digits(5);
+            case 4:
+                return faker.number().numberBetween(7000,8499) + "-" + faker.number().digits(4);
+            case 3:
+                return faker.number().numberBetween(85000,89999) + "-" + faker.number().digits(3);
+            case 2:
+                return faker.number().numberBetween(900000,949999) + "-" + faker.number().digits(2);
+            case 1:
+                return faker.number().numberBetween(9500000,9999999) + "-" + faker.number().digits(1);
+            default:
+                throw new IllegalStateException("Invalid random " + ct);
         }
-        int check = (10 - sum % 10) % 10;
-        isbn13.append(check);
-        return isbn13.toString();
+    }
+
+    /**
+     * @return a valid ISBN10 number with no separators (ex. 9604250590)
+     */
+    public String isbn10() {
+        return isbn10(false);
+    }
+    
+    /**
+     * @param separator true if you want separators returned, false otherwise
+     * @return a valid ISBN10 number with or without separators (ex. 9604250590, 960-425-059-0)
+     */
+    public String isbn10(boolean separator) {
+        // The registration group identifier is a 1- to 5-digit number
+        final StringBuilder isbn10 = new StringBuilder()
+            .append(faker.expression("#{code.isbn_group}"))
+            .append('-')
+            .append(faker.expression("#{code.isbn_registrant}"))
+            .append('-');
+
+        final int checkDigit = isbn10CheckDigit(isbn10);
+        isbn10.append(checkDigit != 10 ? checkDigit : "X");
+        return separator ? isbn10.toString() : stripIsbnSeparator(isbn10);
+    }
+
+    /**
+     * @return a valid ISBN13 number with no separators (ex. 9789604250590)
+     */
+    public String isbn13() {
+        return isbn13(false);
+    }
+
+    /**
+     * @param separator true if you want separators returned, false otherwise
+     * @return a valid ISBN13 number with or without separators (ex. 9789604250590, 978-960-425-059-0)
+     */
+    public String isbn13(boolean separator) {
+        // The registration group identifier is a 1- to 5-digit number
+        final StringBuilder isbn13 = new StringBuilder()
+            .append(faker.expression("#{code.isbn_gs1}"))
+            .append('-')
+            .append(faker.expression("#{code.isbn_group}"))
+            .append('-')
+            .append(faker.expression("#{code.isbn_registrant}"))
+            .append('-');
+
+        final int checkDigit = isbn13CheckDigit(isbn13);
+        isbn13.append(checkDigit);
+        return separator ? isbn13.toString() : stripIsbnSeparator(isbn13);
+    }
+
+    private final int isbn10CheckDigit(CharSequence t) {
+        String value = stripIsbnSeparator(t);
+        int sum = 0;
+        for (int i = 0; i < value.length(); i++) {
+            sum += ((i + 1) * toInt(value.substring(i, i + 1)));
+        }
+        return sum % 11;
+    }
+
+    private final int isbn13CheckDigit(CharSequence t) {
+        String value = stripIsbnSeparator(t);
+        int sum = 0;
+        int multiplier = 0;
+        for (int i = 0; i < value.length(); i++) {
+            multiplier = i % 2 == 0 ? 1 : 3;
+            sum += multiplier * toInt(value.subSequence(i, i + 1).toString());
+        }
+
+        return (10 - sum % 10) % 10;
+    }
+
+    private final String stripIsbnSeparator(CharSequence t) {
+        return t.toString().replaceAll("-","");
     }
 
     public String asin() {

--- a/src/main/java/com/github/javafaker/service/FakeValuesService.java
+++ b/src/main/java/com/github/javafaker/service/FakeValuesService.java
@@ -18,7 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FakeValuesService {
-    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#\\{([a-zA-Z_.]+)\\s?(?:'([^']+)')?(?:,'([^']+)')*\\}");
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#\\{([a-z0-9A-Z_.]+)\\s?(?:'([^']+)')?(?:,'([^']+)')*\\}");
 
     private final Logger log = Logger.getLogger("faker");
     

--- a/src/test/java/com/github/javafaker/AbstractFakerTest.java
+++ b/src/test/java/com/github/javafaker/AbstractFakerTest.java
@@ -25,9 +25,9 @@ public class AbstractFakerTest {
         
         Logger rootLogger = LogManager.getLogManager().getLogger("");
         Handler[] handlers = rootLogger.getHandlers();
-        rootLogger.setLevel(Level.FINEST);
+        rootLogger.setLevel(Level.INFO);
         for (Handler h : handlers) {
-            h.setLevel(Level.FINEST);
+            h.setLevel(Level.INFO);
         }
     }
 

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -1,5 +1,9 @@
 test:
   faker:
+    code:
+      isbn_gs1: ["333","444"]
+      isbn_group: ["9971"]
+      isbn_registrant: ["#{numerify '#-####'}"]
     property:
        dummy: [x, y, z]
        simple: "hello"


### PR DESCRIPTION

Implement valid ISBN numbers.  The implementation will always return valid ISBN numbers for english speaking books.  There is support
for other countries via overrides in the yml files but the values are not currently set.  Default values are constructed in the
Java so that the functionality doesn't break if we bring over the yml files from the stympy/faker project.

A test is included however to show that the values can be customized via yml if we choose to do so.

Fixes DiUS/java-faker#168