### PR TITLE
Fixes #194 handle slash format regex in yml

### DIFF
--- a/src/main/java/com/github/javafaker/service/FakeValuesService.java
+++ b/src/main/java/com/github/javafaker/service/FakeValuesService.java
@@ -171,15 +171,19 @@ public class FakeValuesService {
 
     /**
      * Safely fetches a key.
-     *
+     * <p>
      * If the value is null, it will return an empty string.
-     *
+     * <p>
      * If it is a list, it will assume it is a list of strings and select a random value from it.
-     *
+     * <p>
+     * If the retrieved value is an slash encoded regular expression such as {@code /[a-b]/} then
+     * the regex will be converted to a regexify expression and returned (ex. {@code #regexify '[a-b]'})
+     * <p>
      * Otherwise it will just return the value as a string.
      *
-     * @param key
-     * @return
+     * @param key           the key to fetch from the YML structure.
+     * @param defaultIfNull the value to return if the fetched value is null
+     * @return see above
      */
     @SuppressWarnings("unchecked")
     public String safeFetch(String key, String defaultIfNull) {
@@ -191,6 +195,8 @@ public class FakeValuesService {
                 return defaultIfNull;
             }
             return values.get(randomService.nextInt(values.size()));
+        } else if (isSlashDelimitedRegex(o.toString())) {
+            return String.format("#{regexify '%s'}", trimRegexSlashes(o.toString()));
         } else {
             return (String) o;
         }
@@ -433,6 +439,24 @@ public class FakeValuesService {
         }
         
         return resolved;
+    }
+
+
+    /**
+     * @param expression input expression
+     * @return true if s is non null and is a slash delimited regex (ex. {@code /[ab]/})
+     */
+    private boolean isSlashDelimitedRegex(String expression) {
+        return expression != null && expression.startsWith("/") && expression.endsWith("/");
+    }
+
+    /**
+     * Given a {@code slashDelimitedRegex} such as {@code /[ab]/}, removes the slashes and returns only {@code [ab]}
+     * @param slashDelimitedRegex a non null slash delimited regex (ex. {@code /[ab]/})
+     * @return the regex without the slashes (ex. {@code [ab]})
+     */
+    private String trimRegexSlashes(String slashDelimitedRegex) {
+        return slashDelimitedRegex.substring(1, slashDelimitedRegex.length() - 1);
     }
 
     private boolean isDotDirective(String directive) {

--- a/src/test/java/com/github/javafaker/integration/FakerIT.java
+++ b/src/test/java/com/github/javafaker/integration/FakerIT.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -141,6 +141,10 @@ public class FakerIT {
             logger.info(String.format("%s %s.%s = %s", locale, object.getClass().getSimpleName().toLowerCase(), method.getName(), returnValue));
             assertThat(method + " on " + object, returnValue, is(notNullValue()));
             assertThat(method + " on " + object, (String) returnValue, not(isEmptyString()));
+            assertThat(method + " on " + object + " is not a slash encoded regex", 
+                    ((String) returnValue).endsWith("/") & ((String) returnValue).startsWith("/"),
+                    is(false));
+                    
         }
     }
 

--- a/src/test/java/com/github/javafaker/integration/Issue194SlashFormatRegexIT.java
+++ b/src/test/java/com/github/javafaker/integration/Issue194SlashFormatRegexIT.java
@@ -1,0 +1,39 @@
+package com.github.javafaker.integration;
+
+import com.github.javafaker.Faker;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
+import static org.junit.Assert.assertThat;
+
+public class Issue194SlashFormatRegexIT {
+
+    @Test
+    public void enGBZipCodeReturnsProperRegexifiedValue() {
+        final Locale uk = new Locale("en-GB");
+
+        final String postalCode = new Faker(uk).address().zipCode();
+        
+        assertThat(postalCode, matchesRegularExpression("[A-PR-UWYZ][A-HK-Y]?[0-9][ABEHMNPRVWXY0-9]? [0-9][ABD-HJLNP-UW-Z]{2}"));
+    }
+    
+    @Test
+    public void enCAZipCodeReturnsProperRegexifiedValue() {
+        final Locale uk = new Locale("en-CA");
+
+        final String postalCode = new Faker(uk).address().zipCode();
+
+        assertThat(postalCode, matchesRegularExpression("[A-CEJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]"));
+    }
+    
+    @Test
+    public void viZipCodeReturnsProperRegexifiedValue() {
+        final Locale uk = new Locale("vi");
+
+        final String postalCode = new Faker(uk).address().zipCode();
+
+        assertThat(postalCode, matchesRegularExpression("[A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}"));
+    }
+}

--- a/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
@@ -94,6 +94,16 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         verify(faker).regexify("[45]{2}");
     }
 
+
+    @Test
+    public void regexifySlashFormatDirective() {
+        final DummyService dummy = mock(DummyService.class);
+
+        String value = fakeValuesService.resolve("property.regexify_slash_format", dummy, faker);
+        assertThat(value, either(is("55")).or(is("44")).or(is("45")).or(is("54")));
+        verify(faker).regexify("[45]{2}");
+    }
+
     @Test
     public void regexifyDirective2() {
         final DummyService dummy = mock(DummyService.class);

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -11,6 +11,7 @@ test:
        advancedResolution: "#{Superhero.name}"
        regexify1: "#{regexify '[45]{2}'}"
        regexify_cell: "#{regexify '4[57]9'}"
+       regexify_slash_format: /[45]{2}/
        bothify_2: "#{bothify '??##','true'}"
        multipleResolution: "#{hello} #{Superhero.descriptor}"
        resolutionWithList:


### PR DESCRIPTION
Handle slash format (ex. /[a-b]+/) regular expressions in .yml files.
This is handled internally in the safeFetch method by converting the statement from the /x/ format to
the #{regexify 'x'} directive format.