### PR TITLE
update test dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.24</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.24</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,13 +92,13 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
+            <version>0.9.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.26</version>
+            <version>2.7.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -1,14 +1,12 @@
 package com.github.javafaker;
 
 import com.github.javafaker.repeating.Repeat;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.validator.routines.EmailValidator;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 
@@ -32,7 +30,6 @@ public class InternetTest extends AbstractFakerTest {
         assertThat(EmailValidator.getInstance().isValid(emailAddress), is(true));
     }
 
-
     @Test
     public void testSafeEmailAddress() {
         List<String> emails = Lists.newArrayList();
@@ -42,13 +39,9 @@ public class InternetTest extends AbstractFakerTest {
             emails.add(emailAddress);
         }
         final String safeDomain = faker.resolve("internet.safe_email");
-        boolean foundSafeDomainEmail = Iterables.any(emails, new Predicate<String>() {
-            @Override
-            public boolean apply(@Nullable String s) {
-                return s.endsWith("@" + safeDomain);
-            }});
-        
-        assertThat("Should find at least one email from " + safeDomain, foundSafeDomainEmail, is(true));
+
+        assertThat("Should find at least one email from " + safeDomain, emails,
+                Matchers.hasItem(Matchers.endsWith("@" + safeDomain)));
     }
 
     @Test
@@ -61,13 +54,9 @@ public class InternetTest extends AbstractFakerTest {
             emails.add(emailAddress);
         }
         final String safeDomain = faker.resolve("internet.safe_email");
-        boolean foundSafeDomainEmail = Iterables.any(emails, new Predicate<String>() {
-            @Override
-            public boolean apply(@Nullable String s) {
-                return s.endsWith("@" + safeDomain);
-            }});
 
-        assertThat("Should find at least one email from " + safeDomain, foundSafeDomainEmail, is(true));
+        assertThat("Should find at least one email from " + safeDomain, emails,
+                Matchers.hasItem(Matchers.endsWith("@" + safeDomain)));
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/NumberTest.java
+++ b/src/test/java/com/github/javafaker/NumberTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
@@ -163,7 +162,7 @@ public class NumberTest extends AbstractFakerTest {
     
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = new Function<Pair<Long, Long>, Double>() {
             @Override
-            public Double apply(@Nullable Pair<Long, Long> minMax) {
+            public Double apply(Pair<Long, Long> minMax) {
                 final int min = minMax.getLeft().intValue(),
                         max = minMax.getRight().intValue();
                 long numbersToGet = calculateNumbersToGet(min, max);
@@ -205,7 +204,7 @@ public class NumberTest extends AbstractFakerTest {
         
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = new Function<Pair<Long, Long>, Double>() {
             @Override
-            public Double apply(@Nullable Pair<Long, Long> minMax) {
+            public Double apply(Pair<Long, Long> minMax) {
                 final int min = minMax.getLeft().intValue(), 
                         max = minMax.getRight().intValue();
                 long numbersToGet = calculateNumbersToGet(min, max);
@@ -248,7 +247,7 @@ public class NumberTest extends AbstractFakerTest {
 
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = new Function<Pair<Long, Long>, Double>() {
             @Override
-            public Double apply(@Nullable Pair<Long, Long> minMax) {
+            public Double apply(Pair<Long, Long> minMax) {
                 final long min = minMax.getLeft(), max = minMax.getRight();
                 long numbersToGet = calculateNumbersToGet(min, max);
 


### PR DESCRIPTION
remove usage of javax.annotation.Nullable in test, as this transitive test dependency does not exit anymore