### PR TITLE
Update pt-BR.yml

### DIFF
--- a/src/main/resources/pt-BR.yml
+++ b/src/main/resources/pt-BR.yml
@@ -26,6 +26,8 @@ pt-BR:
                  "Estados Unidos das Ilhas Virgens", "Uruguai", "Uzbequistão", "Vanuatu", "Venezuela", "Vietnã", "Wallis e Futuna", "Saara Ocidental", "Iémen", "Zâmbia", "Zimbábue"]
       building_number: ["#####", "####", "###", "s/n"]
       street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
+      street_address:
+        - "#{street_name} #{building_number}"
       street_name:
         - "#{street_suffix} #{Name.first_name}"
         - "#{street_suffix} #{Name.first_name} #{Name.last_name}"


### PR DESCRIPTION
In Brazil the street address starts with the street name.
Current the street_address starts with building_number to, after, put the street_name.

This change will put first the street_name and after the building_number