### PR TITLE
Update pt-BR.yml

### DIFF
--- a/src/main/resources/pt-BR.yml
+++ b/src/main/resources/pt-BR.yml
@@ -25,6 +25,10 @@ pt-BR:
                  "Turquia", "Turcomenistão", "Ilhas Turcas e Caicos", "Tuvalu", "Uganda", "Ucrânia", "Emirados Árabes Unidos", "Reino Unido", "Estados Unidos da América",
                  "Estados Unidos das Ilhas Virgens", "Uruguai", "Uzbequistão", "Vanuatu", "Venezuela", "Vietnã", "Wallis e Futuna", "Saara Ocidental", "Iémen", "Zâmbia", "Zimbábue"]
       building_number: ["#####", "####", "###", "s/n"]
+      full_address:
+       - "#{street_name}, #{building_number} - #{city}/#{state_abbr} - CEP: #{zip_code}"
+       - "#{street_name}, #{building_number} #{secondary_address} - #{city}/#{state_abbr} - CEP: #{zip_code}"
+      street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
       street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
       street_name:
         - "#{street_suffix} #{Name.first_name}"


### PR DESCRIPTION
Full address where have two following patterns:
   - "#{street_name}, #{building_number} - #{city}/#{state_abbr} - CEP: #{zip_code}"
   - "#{street_name}, #{building_number} #{secondary_address} - #{city}/#{state_abbr} - CEP: #{zip_code}"

The full address starts always with the street name. We put a backslash between city and state abbreviation and always the zip code abbreviation before the zip code (CEP)