### PR TITLE
Use month values between 0-11 for GregorianCalendar

### DIFF
--- a/src/main/java/com/github/javafaker/DateAndTime.java
+++ b/src/main/java/com/github/javafaker/DateAndTime.java
@@ -119,7 +119,7 @@ public class DateAndTime {
      *
      * @return a random birthday between 65 and 18 years ago.
      */
-    public java.util.Date birthday() {
+    public Date birthday() {
         return birthday(DEFAULT_MIN_AGE, DEFAULT_MAX_AGE);
     }
 
@@ -134,10 +134,10 @@ public class DateAndTime {
      * @throws IllegalArgumentException
      *             if the {@code maxAge} is lower than {@code minAge}.
      */
-    public java.util.Date birthday(int minAge, int maxAge) {
+    public Date birthday(int minAge, int maxAge) {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         Calendar from = new GregorianCalendar(currentYear - maxAge, 0, 1);
-        Calendar to = new GregorianCalendar(currentYear - minAge, 12, 31);
+        Calendar to = new GregorianCalendar(currentYear - minAge, 11, 31);
 
         return between(from.getTime(), to.getTime());
     }

--- a/src/test/java/com/github/javafaker/DateAndTimeTest.java
+++ b/src/test/java/com/github/javafaker/DateAndTimeTest.java
@@ -63,7 +63,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     public void testBirthday() {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         long from = new GregorianCalendar(currentYear - 65, 0, 1).getTime().getTime();
-        long to = new GregorianCalendar(currentYear - 18, 12, 31).getTime().getTime();
+        long to = new GregorianCalendar(currentYear - 18, 11, 31).getTime().getTime();
 
         for (int i = 0; i < 1000; i++) {
             Date birthday = faker.date().birthday();
@@ -81,7 +81,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
             int maxAge = faker.number().numberBetween(minAge, 100);
 
             long from = new GregorianCalendar(currentYear - maxAge, 0, 1).getTime().getTime();
-            long to = new GregorianCalendar(currentYear - minAge, 12, 31).getTime().getTime();
+            long to = new GregorianCalendar(currentYear - minAge, 11, 31).getTime().getTime();
 
             Date birthday = faker.date().birthday(minAge, maxAge);
             assertThat("birthday is after upper bound", birthday.getTime(), lessThan(to));


### PR DESCRIPTION
Hi!

Thanks for java-faker, saved me some time writing tests this past week.

I think GregorianCalendar's month is 0-based, and in the birthday faker it would result in an error?

This pull request changes the value from 12 to 11. Also removed the unnecessary canonical name for `java.util.Date` which was already imported.

Thanks again
Bruno