### PR TITLE
Travis CI no longer supports oraclejdk7 (https://github.com/travis-ci…

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,2 @@
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 dist: trusty
-sudo: false
+sudo: required
 jdk:
 - oraclejdk8
 - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-dist: trusty
+dist: precise
 sudo: required
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
+dist: trusty
 jdk:
-- oraclejdk7
 - oraclejdk8
 - openjdk7
 script: "mvn verify failsafe:integration-test failsafe:verify"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 dist: trusty
+sudo: false
 jdk:
 - oraclejdk8
 - openjdk7


### PR DESCRIPTION
…/travis-ci/issues/7019). Changing distribution to make openjdk7 working.