### PR TITLE
Step back to ubuntu precise.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 jdk:
 - oraclejdk7
 - oraclejdk8


### PR DESCRIPTION
Recently Travis CI introduced ubuntu:trusty as a default environment. Unfortunately, it has 2 issues which affects this repository:
1) oraclejdk7 is no longer supported due to Oracle's withdrawal. See details: https://github.com/travis-ci/travis-ci/issues/7884 and example failing build: https://travis-ci.org/DiUS/java-faker/jobs/273565200)
2) openjdk7 is supported on trusty, however there is a problem with shading snakeyaml library caused by lack of SunEC provider. See details: https://github.com/docker-library/openjdk/issues/117 and example failing build https://travis-ci.org/DiUS/java-faker/jobs/273565202