### PR TITLE
Adding overloaded method to allow a specific credit card format to be returned

### DIFF
--- a/src/main/java/com/github/javafaker/Finance.java
+++ b/src/main/java/com/github/javafaker/Finance.java
@@ -18,10 +18,10 @@ public class Finance {
 
     private static final Map<String, String> countryCodeToBasicBankAccountNumberPattern =
             createCountryCodeToBasicBankAccountNumberPatternMap();
-//
-    public String creditCard() {
-        CreditCardType type = randomCreditCardType();
-        final String key = String.format("credit_card.%s", type.toString().toLowerCase());
+
+    public String creditCard(CreditCardType creditCardType)
+    {
+        final String key = String.format("credit_card.%s", creditCardType.toString().toLowerCase());
         String value = faker.fakeValuesService().resolve(key, this, faker);
         final String template = faker.numerify(value);
 
@@ -41,6 +41,11 @@ public class Finance {
         }
         int luhnDigit = (10 - (luhnSum % 10)) % 10;
         return template.replace('\\', ' ').replace('/', ' ').trim().replace('L', String.valueOf(luhnDigit).charAt(0));
+    }
+
+    public String creditCard() {
+        CreditCardType type = randomCreditCardType();
+        return creditCard(type);
     }
 
     /**

--- a/src/main/java/com/github/javafaker/Finance.java
+++ b/src/main/java/com/github/javafaker/Finance.java
@@ -19,8 +19,7 @@ public class Finance {
     private static final Map<String, String> countryCodeToBasicBankAccountNumberPattern =
             createCountryCodeToBasicBankAccountNumberPatternMap();
 
-    public String creditCard(CreditCardType creditCardType)
-    {
+    public String creditCard(CreditCardType creditCardType) {
         final String key = String.format("credit_card.%s", creditCardType.toString().toLowerCase());
         String value = faker.fakeValuesService().resolve(key, this, faker);
         final String template = faker.numerify(value);

--- a/src/test/java/com/github/javafaker/FinanceTest.java
+++ b/src/test/java/com/github/javafaker/FinanceTest.java
@@ -39,8 +39,7 @@ public class FinanceTest extends AbstractFakerTest {
 
     @Test
     public void creditCardWithType() {
-        for(CreditCardType type : CreditCardType.values())
-        {
+        for(CreditCardType type : CreditCardType.values()) {
             final String creditCard = faker.finance().creditCard(type);
             assertCardLuhnDigit(creditCard);
         }

--- a/src/test/java/com/github/javafaker/FinanceTest.java
+++ b/src/test/java/com/github/javafaker/FinanceTest.java
@@ -38,8 +38,7 @@ public class FinanceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void creditCardWithType()
-    {
+    public void creditCardWithType() {
         for(CreditCardType type : CreditCardType.values())
         {
             final String creditCard = faker.finance().creditCard(type);

--- a/src/test/java/com/github/javafaker/FinanceTest.java
+++ b/src/test/java/com/github/javafaker/FinanceTest.java
@@ -13,9 +13,13 @@ public class FinanceTest extends AbstractFakerTest {
     public void creditCard() {
         for (int i = 0; i < 100; i++) {
             final String creditCard = faker.finance().creditCard();
-            final String creditCardStripped = creditCard.replaceAll("-", "");
-            assertThat(LuhnCheckDigit.LUHN_CHECK_DIGIT.isValid(creditCardStripped), is(true));
+            assertCardLuhnDigit(creditCard);
         }
+    }
+
+    private void assertCardLuhnDigit(String creditCard) {
+        final String creditCardStripped = creditCard.replaceAll("-", "");
+        assertThat(LuhnCheckDigit.LUHN_CHECK_DIGIT.isValid(creditCardStripped), is(true));
     }
 
     @Test
@@ -31,5 +35,15 @@ public class FinanceTest extends AbstractFakerTest {
     @Test
     public void ibanWithCountryCode() {
         assertThat(faker.finance().iban("DE"), matchesRegularExpression("DE\\d{20}"));
+    }
+
+    @Test
+    public void creditCardWithType()
+    {
+        for(CreditCardType type : CreditCardType.values())
+        {
+            final String creditCard = faker.finance().creditCard(type);
+            assertCardLuhnDigit(creditCard);
+        }
     }
 }


### PR DESCRIPTION
This method allows specific credit card types to be returned. This is useful for testing purposes when someone needs to ensure they test only a certain subset of credit cards, e.g Visa and Mastercard, but not AMEX.

Added unit test.