### PR TITLE
Rename static factory method

### DIFF
--- a/src/main/java/com/github/javafaker/Faker.java
+++ b/src/main/java/com/github/javafaker/Faker.java
@@ -144,7 +144,7 @@ public class Faker {
      *
      * @return {@link Faker#Faker()}
      */
-    public static Faker instance() {
+    public static Faker faker() {
         return new Faker();
     }
 
@@ -154,7 +154,7 @@ public class Faker {
      * @param locale - {@link Locale}
      * @return {@link Faker#Faker(Locale)}
      */
-    public static Faker instance(Locale locale) {
+    public static Faker faker(Locale locale) {
         return new Faker(locale);
     }
 
@@ -164,7 +164,7 @@ public class Faker {
      * @param random - {@link Random}
      * @return {@link Faker#Faker(Random)}
      */
-    public static Faker instance(Random random) {
+    public static Faker faker(Random random) {
         return new Faker(random);
     }
 
@@ -175,7 +175,7 @@ public class Faker {
      * @param random - {@link Random}
      * @return {@link Faker#Faker(Locale, Random)}
      */
-    public static Faker instance(Locale locale, Random random) {
+    public static Faker faker(Locale locale, Random random) {
         return new Faker(locale, random);
     }
 

--- a/src/test/java/com/github/javafaker/FakerTest.java
+++ b/src/test/java/com/github/javafaker/FakerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.Random;
 
+import static com.github.javafaker.Faker.*;
 import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -157,9 +158,9 @@ public class FakerTest extends AbstractFakerTest {
 
     @Test
     public void fakerInstanceCanBeAcquiredViaUtilityMethods() {
-        assertThat(Faker.instance(), is(instanceOf(Faker.class)));
-        assertThat(Faker.instance(Locale.CANADA), is(instanceOf(Faker.class)));
-        assertThat(Faker.instance(new Random(1)), is(instanceOf(Faker.class)));
-        assertThat(Faker.instance(Locale.CHINA, new Random(2)), is(instanceOf(Faker.class)));
+        assertThat(faker(), is(instanceOf(Faker.class)));
+        assertThat(faker(Locale.CANADA), is(instanceOf(Faker.class)));
+        assertThat(faker(new Random(1)), is(instanceOf(Faker.class)));
+        assertThat(faker(Locale.CHINA, new Random(2)), is(instanceOf(Faker.class)));
     }
 }


### PR DESCRIPTION
Since static import is neat way to reduce
line lengths it also becomes confusing
if code reads:

```
instance()...
```

so the trail of though automatically becomes:
> instance of what?!!  

thus I decided to follow up with a rename.
See static import in unit test.