### PR TITLE
Add UUID to faker

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.join;
 
@@ -282,6 +283,10 @@ public class Internet {
             slug.append(words.get(i));
         }
         return slug.toString();
+    }
+
+    public String uuid() {
+        return UUID.randomUUID().toString();
     }
           
     private <T> T random(T[] src) {

--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -285,6 +285,10 @@ public class Internet {
         return slug.toString();
     }
 
+    /**
+     * Returns a UUID (type 4) as String.
+     * @return A UUID as String.
+     */
     public String uuid() {
         return UUID.randomUUID().toString();
     }

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -13,7 +13,16 @@ import java.util.Locale;
 import static com.github.javafaker.matchers.CountOfCharactersMatcher.countOf;
 import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static java.lang.Integer.parseInt;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public class InternetTest extends AbstractFakerTest {
@@ -236,6 +245,12 @@ public class InternetTest extends AbstractFakerTest {
     @Repeat(times=10)
     public void testSlug() {
         assertThat(faker.internet().slug(), matchesRegularExpression("[a-zA-Z]+\\_[a-zA-Z]+"));
+    }
+
+    @Test
+    @Repeat(times=10)
+    public void testUuid() {
+        assertThat(faker.internet().uuid(), matchesRegularExpression("/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds a faker for an UUID to the internet faker. Usage:

```
String uuid = faker.internet().uuid()
```

I got the regex used in the test from https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid