### PR TITLE
Replace StringBuffer by StringBuilder

### DIFF
--- a/src/main/java/com/github/javafaker/service/FakeValuesService.java
+++ b/src/main/java/com/github/javafaker/service/FakeValuesService.java
@@ -236,7 +236,7 @@ public class FakeValuesService {
      * @return
      */
     public String numerify(String numberString) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < numberString.length(); i++) {
             if (numberString.charAt(i) == '#') {
                 sb.append(randomService.nextInt(10));
@@ -308,7 +308,7 @@ public class FakeValuesService {
     }
 
     private String letterHelper(int baseChar, String letterString) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < letterString.length(); i++) {
             if (letterString.charAt(i) == '?') {
                 sb.append((char) (baseChar + randomService.nextInt(26))); // a-z


### PR DESCRIPTION
Hi,

Not sure if it was intentional, or just reminiscent from some older code. I couldn't find any reason for having `StringBuffer` instead of `StringBuilder`, nor any javadocs about threads and synchronization.

I believe it won't cause any regression. And while these two methods (`#numerify` and `#letterHelper`) used `StringBuffer`s, the constructor  uses `StringBuilder`, and other parts of the code also use `StringBuilder`s (e.g. `Code#isbn10`, `FakerIDN#toASCII`, ...).

Quickly created the pull request from GitHub interface, but hopefully Travis CI will build it and confirm it works fine. Found it while using the IDE to find occurrences of these classes in a legacy code at work.

Cheers
Bruno