### PR TITLE
Remove whitespaces from usernames (#296)

### DIFF
--- a/src/main/java/com/github/javafaker/Name.java
+++ b/src/main/java/com/github/javafaker/Name.java
@@ -3,11 +3,11 @@ package com.github.javafaker;
 import org.apache.commons.lang3.StringUtils;
 
 public class Name {
-
+    
     private final Faker faker;
 
     /**
-     * Internal constructor, not to be used by clients.  Instances of {@link Name} should be accessed via
+     * Internal constructor, not to be used by clients.  Instances of {@link Name} should be accessed via 
      * {@link Faker#name()}.
      */
     protected Name(Faker faker) {
@@ -32,7 +32,7 @@ public class Name {
     /**
      * <p>
      *      A multipart name composed of an optional prefix, a given and family name,
-     *      another 'firstname' for the middle name and an optional suffix such as Jr.
+     *      another 'firstname' for the middle name and an optional suffix such as Jr. 
      *      Examples:
      *      <ul>
      *          <li>Mrs. Ella Geraldine Fitzgerald</li>
@@ -48,7 +48,7 @@ public class Name {
 
     /**
      * <p>Returns the same value as {@link #name()}</p>
-     * @see Name#name()
+     * @see Name#name() 
      */
     public String fullName() {
         return name();
@@ -100,8 +100,8 @@ public class Name {
      */
     public String title() {
         return StringUtils.join(new String[] {
-            faker.fakeValuesService().resolve("name.title.descriptor", this, faker),
-            faker.fakeValuesService().resolve("name.title.level", this, faker),
+            faker.fakeValuesService().resolve("name.title.descriptor", this, faker), 
+            faker.fakeValuesService().resolve("name.title.level", this, faker), 
             faker.fakeValuesService().resolve("name.title.job", this, faker) }, " ");
     }
 
@@ -116,7 +116,7 @@ public class Name {
      *     </ul>
      * </p>
      * @return a random two part user name.
-     * @see Name#firstName()
+     * @see Name#firstName() 
      * @see Name#lastName()
      */
     public String username() {

--- a/src/main/java/com/github/javafaker/Name.java
+++ b/src/main/java/com/github/javafaker/Name.java
@@ -3,11 +3,11 @@ package com.github.javafaker;
 import org.apache.commons.lang3.StringUtils;
 
 public class Name {
-    
+
     private final Faker faker;
 
     /**
-     * Internal constructor, not to be used by clients.  Instances of {@link Name} should be accessed via 
+     * Internal constructor, not to be used by clients.  Instances of {@link Name} should be accessed via
      * {@link Faker#name()}.
      */
     protected Name(Faker faker) {
@@ -32,7 +32,7 @@ public class Name {
     /**
      * <p>
      *      A multipart name composed of an optional prefix, a given and family name,
-     *      another 'firstname' for the middle name and an optional suffix such as Jr. 
+     *      another 'firstname' for the middle name and an optional suffix such as Jr.
      *      Examples:
      *      <ul>
      *          <li>Mrs. Ella Geraldine Fitzgerald</li>
@@ -48,7 +48,7 @@ public class Name {
 
     /**
      * <p>Returns the same value as {@link #name()}</p>
-     * @see Name#name() 
+     * @see Name#name()
      */
     public String fullName() {
         return name();
@@ -100,8 +100,8 @@ public class Name {
      */
     public String title() {
         return StringUtils.join(new String[] {
-            faker.fakeValuesService().resolve("name.title.descriptor", this, faker), 
-            faker.fakeValuesService().resolve("name.title.level", this, faker), 
+            faker.fakeValuesService().resolve("name.title.descriptor", this, faker),
+            faker.fakeValuesService().resolve("name.title.level", this, faker),
             faker.fakeValuesService().resolve("name.title.job", this, faker) }, " ");
     }
 
@@ -116,14 +116,17 @@ public class Name {
      *     </ul>
      * </p>
      * @return a random two part user name.
-     * @see Name#firstName() 
+     * @see Name#firstName()
      * @see Name#lastName()
      */
     public String username() {
-        return StringUtils.join(new String[]{
+
+        String username = StringUtils.join(new String[]{
                 firstName().replaceAll("'", "").toLowerCase(),
                 ".",
                 lastName().replaceAll("'", "").toLowerCase()}
         );
+
+        return StringUtils.deleteWhitespace(username);
     }
 }

--- a/src/test/java/com/github/javafaker/NameTest.java
+++ b/src/test/java/com/github/javafaker/NameTest.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 
 import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
 
 public class NameTest  extends AbstractFakerTest{
 
@@ -51,4 +54,13 @@ public class NameTest  extends AbstractFakerTest{
     public void testUsername() {
         assertThat(faker.name().username(), matchesRegularExpression("^(\\w+)\\.(\\w+)$"));
     }
+
+    @Test
+    public void testUsernameWithSpaces() {
+        final Name name = spy(new Name(faker));
+        doReturn("Compound Name").when(name).firstName();
+        doReturn(name).when(faker).name();
+        assertThat(faker.name().username(), matchesRegularExpression("^(\\w+)\\.(\\w+)$"));
+    }
+
 }


### PR DESCRIPTION
Some languages include compound names (spanish and portugese for
example) and that breaks username and email validation.