### PR TITLE
Enable TLS 1.2 protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ jdk:
 - oraclejdk7
 - oraclejdk8
 - openjdk7
-script: "mvn verify failsafe:integration-test failsafe:verify"
+script: "mvn -Dhttps.protocols=TLSv1.2 verify failsafe:integration-test failsafe:verify"
 branches:
   except:
   - travis
 notifications:
   email: false
 after_success:
-- mvn clean cobertura:cobertura coveralls:cobertura
+- mvn -Dhttps.protocols=TLSv1.2 clean cobertura:cobertura coveralls:cobertura

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: java
-dist: precise
+dist: trusty
 jdk:
 - oraclejdk7
 - oraclejdk8
 - openjdk7
-script: "mvn -Dhttps.protocols=TLSv1.2 verify failsafe:integration-test failsafe:verify"
+script: "mvn verify failsafe:integration-test failsafe:verify"
 branches:
   except:
   - travis
 notifications:
   email: false
 after_success:
-- mvn -Dhttps.protocols=TLSv1.2 clean cobertura:cobertura coveralls:cobertura
+- mvn clean cobertura:cobertura coveralls:cobertura


### PR DESCRIPTION
As of June 18th 2018, Central (repo1.maven.org & repo.maven.apache.org) supports TLS 1.2 only - https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/