### PR TITLE
Upgrade to trusty and remove oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
-dist: precise
+dist: trusty
 jdk:
-- oraclejdk7
 - oraclejdk8
 - openjdk7
 script: "mvn verify failsafe:integration-test failsafe:verify"


### PR DESCRIPTION
Recent PRs (#302 #303) have failed on openjdk7 and oraclejdk7 due to [discontinued support for TLS v1.1](https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/)

I wasn't able to find a way to make sure it uses TLS v1.2, so I upgraded to Trusty. I had to remove oraclejdk7 on Trusty since [oracle JDK 7 is not provided because it reached End of Life in April 2015](https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images)

