### PR TITLE
This PR fixes a potential issue with the decimalBetween function where the max value may be included

### DIFF
--- a/src/main/java/com/github/javafaker/Number.java
+++ b/src/main/java/com/github/javafaker/Number.java
@@ -27,7 +27,7 @@ public class Number {
      * @see Number#numberBetween(long, long) 
      */
     public int numberBetween(int min, int max) {
-        return decimalBetween(min,max).setScale(0, BigDecimal.ROUND_HALF_DOWN).intValue();
+        return decimalBetween(min,max).setScale(0, BigDecimal.ROUND_FLOOR).intValue();
     }
 
     /**

--- a/src/test/java/com/github/javafaker/FakerTest.java
+++ b/src/test/java/com/github/javafaker/FakerTest.java
@@ -1,5 +1,6 @@
 package com.github.javafaker;
 
+import com.github.javafaker.repeating.Repeat;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -122,6 +123,7 @@ public class FakerTest extends AbstractFakerTest {
     }
 
     @Test
+    @Repeat(times = 100)
     public void expression() {
         assertThat(faker.expression("#{regexify '(a|b){2,3}'}"), matchesRegularExpression("(a|b){2,3}"));
         assertThat(faker.expression("#{regexify '\\.\\*\\?\\+'}"), matchesRegularExpression("\\.\\*\\?\\+"));


### PR DESCRIPTION
I had noticed that very occasionally the unit test for the Faker class would fail
On further investigation the issue seemed to originate from the rounding method for the BigDecimal setScale.

This PR replaces the ROUND_HALF_DOWN rounding method with ROUND_FLOOR. 
The associated unit test has been updated to use the Repeat annotation to add additional coverage to account for the randomness of the function.