### PR TITLE
Strip accents on email address to conform with RFC 5322

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.stripAccents;
 
 public class Internet {
     private final Faker faker;
@@ -22,9 +23,7 @@ public class Internet {
     }
 
     public String emailAddress(String localPart) {
-        return join(localPart,
-                "@",
-                FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.free_email", this, faker)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.free_email", this, faker)));
     }
 
     public String safeEmailAddress() {
@@ -32,9 +31,11 @@ public class Internet {
     }
 
     public String safeEmailAddress(String localPart) {
-        return join(localPart, 
-                "@",
-                FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.safe_email", this, faker)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.safe_email", this, faker)));
+    }
+
+    private String emailAddress(String localPart, String domain) {
+        return join(stripAccents(localPart), "@", domain);
     }
 
     public String domainName() {

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -70,6 +70,18 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
+    public void testEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+        String emailAddress = faker.internet().emailAddress("áéíóú");
+        assertThat(emailAddress, startsWith("aeiou@"));
+    }
+
+    @Test
+    public void testSafeEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+        String emailAddress = faker.internet().safeEmailAddress("áéíóú");
+        assertThat(emailAddress, startsWith("aeiou@"));
+    }
+
+    @Test
     public void testUrl() {
         assertThat(faker.internet().url(), matchesRegularExpression("www\\.(\\w|-)+\\.\\w+"));
     }


### PR DESCRIPTION
More info on issue #296 (comment by @gregod).

Please, feel free to suggest any changes :)