### PR TITLE
Generate Dates in future or past with minimum distance from now

### DIFF
--- a/src/main/java/com/github/javafaker/DateAndTime.java
+++ b/src/main/java/com/github/javafaker/DateAndTime.java
@@ -53,7 +53,7 @@ public class DateAndTime {
     public Date future(int atMost, int minimum, TimeUnit unit) {
         Date now = new Date();
         Date minimumDate = new Date(now.getTime() + unit.toMillis(minimum));
-        return future(atMost, unit, minimumDate);
+        return future(atMost - minimum, unit, minimumDate);
     }
 
     /**
@@ -105,7 +105,7 @@ public class DateAndTime {
     public Date past(int atMost, int minimum, TimeUnit unit) {
         Date now = new Date();
         Date minimumDate = new Date(now.getTime() - unit.toMillis(minimum));
-        return past(atMost, unit, minimumDate);
+        return past(atMost - minimum, unit, minimumDate);
     }
 
     /**

--- a/src/main/java/com/github/javafaker/DateAndTime.java
+++ b/src/main/java/com/github/javafaker/DateAndTime.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.github.javafaker;
 
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A generator of random dates.
- * 
+ *
  * @author pmiklos
  *
  */
@@ -26,7 +26,7 @@ public class DateAndTime {
 
     /**
      * Generates a future date from now. Note that there is a 1 second slack to avoid generating a past date.
-     * 
+     *
      * @param atMost
      *            at most this amount of time ahead from now exclusive.
      * @param unit
@@ -40,8 +40,25 @@ public class DateAndTime {
     }
 
     /**
+     * Generates a future date from now, with a minimum time.
+     *
+     * @param atMost
+     *            at most this amount of time ahead from now exclusive.
+     * @param minimum
+     *            the minimum amount of time in the future from now.
+     * @param unit
+     *            the time unit.
+     * @return a future date from now.
+     */
+    public Date future(int atMost, int minimum, TimeUnit unit) {
+        Date now = new Date();
+        Date minimumDate = new Date(now.getTime() + unit.toMillis(minimum));
+        return future(atMost, unit, minimumDate);
+    }
+
+    /**
      * Generates a future date relative to the {@code referenceDate}.
-     * 
+     *
      * @param atMost
      *            at most this amount of time ahead to the {@code referenceDate} exclusive.
      * @param unit
@@ -61,7 +78,7 @@ public class DateAndTime {
 
     /**
      * Generates a past date from now. Note that there is a 1 second slack added.
-     * 
+     *
      * @param atMost
      *            at most this amount of time earlier from now exclusive.
      * @param unit
@@ -75,8 +92,25 @@ public class DateAndTime {
     }
 
     /**
+     * Generates a past date from now, with a minimum time.
+     *
+     * @param atMost
+     *            at most this amount of time earlier from now exclusive.
+     * @param minimum
+     *            the minimum amount of time in the past from now.
+     * @param unit
+     *            the time unit.
+     * @return a past date from now.
+     */
+    public Date past(int atMost, int minimum, TimeUnit unit) {
+        Date now = new Date();
+        Date minimumDate = new Date(now.getTime() - unit.toMillis(minimum));
+        return past(atMost, unit, minimumDate);
+    }
+
+    /**
      * Generates a past date relative to the {@code referenceDate}.
-     * 
+     *
      * @param atMost
      *            at most this amount of time past to the {@code referenceDate} exclusive.
      * @param unit
@@ -96,7 +130,7 @@ public class DateAndTime {
 
     /**
      * Generates a random date between two dates.
-     * 
+     *
      * @param from
      *            the lower bound inclusive
      * @param to

--- a/src/test/java/com/github/javafaker/DateAndTimeTest.java
+++ b/src/test/java/com/github/javafaker/DateAndTimeTest.java
@@ -31,25 +31,23 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @Test
     public void testFutureDateWithMinimum(){
-        Date now = new Date();
-
         for (int i = 0; i < 1000; i++) {
+            Date now = new Date();
             Date future = faker.date().future(5, 4, TimeUnit.SECONDS);
             assertThat("past date", future.getTime(), greaterThan(now.getTime()));
-            assertThat("future date over range", future.getTime(), lessThan(now.getTime() + 5000));
-            assertThat("future date under minimum range", future.getTime(), greaterThan(now.getTime() + 4000));
+            assertThat("future date over range", future.getTime(), lessThan(now.getTime() + 5001));
+            assertThat("future date under minimum range", future.getTime(), greaterThan(now.getTime() + 3999));
         }
     }
 
     @Test
     public void testPastDateWithMinimum(){
-        Date now = new Date();
-
         for (int i = 0; i < 1000; i++) {
+            Date now = new Date();
             Date past = faker.date().past(5, 4, TimeUnit.SECONDS);
             assertThat("future date", past.getTime(), lessThan(now.getTime()));
-            assertThat("past date over range", past.getTime(), greaterThan(now.getTime() - 5000));
-            assertThat("past date under minimum range", past.getTime(), lessThan(now.getTime() - 4000));
+            assertThat("past date over range", past.getTime(), greaterThan(now.getTime() - 5001));
+            assertThat("past date under minimum range", past.getTime(), lessThan(now.getTime() - 3999));
         }
     }
 

--- a/src/test/java/com/github/javafaker/DateAndTimeTest.java
+++ b/src/test/java/com/github/javafaker/DateAndTimeTest.java
@@ -30,6 +30,30 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
+    public void testFutureDateWithMinimum(){
+        Date now = new Date();
+
+        for (int i = 0; i < 1000; i++) {
+            Date future = faker.date().future(5, 4, TimeUnit.SECONDS);
+            assertThat("past date", future.getTime(), greaterThan(now.getTime()));
+            assertThat("future date over range", future.getTime(), lessThan(now.getTime() + 5001));
+            assertThat("future date under minimum range", future.getTime(), greaterThan(now.getTime() + 3999));
+        }
+    }
+
+    @Test
+    public void testPastDateWithMinimum(){
+        Date now = new Date();
+
+        for (int i = 0; i < 1000; i++) {
+            Date past = faker.date().past(5, 4, TimeUnit.SECONDS);
+            assertThat("future date", past.getTime(), lessThan(now.getTime()));
+            assertThat("past date over range", past.getTime(), greaterThan(now.getTime() - 5001));
+            assertThat("past date under minimum range", past.getTime(), lessThan(now.getTime() - 3999));
+        }
+    }
+
+    @Test
     public void testPastDateWithReferenceDate() {
         Date now = new Date();
 

--- a/src/test/java/com/github/javafaker/DateAndTimeTest.java
+++ b/src/test/java/com/github/javafaker/DateAndTimeTest.java
@@ -36,8 +36,8 @@ public class DateAndTimeTest extends AbstractFakerTest {
         for (int i = 0; i < 1000; i++) {
             Date future = faker.date().future(5, 4, TimeUnit.SECONDS);
             assertThat("past date", future.getTime(), greaterThan(now.getTime()));
-            assertThat("future date over range", future.getTime(), lessThan(now.getTime() + 5001));
-            assertThat("future date under minimum range", future.getTime(), greaterThan(now.getTime() + 3999));
+            assertThat("future date over range", future.getTime(), lessThan(now.getTime() + 5000));
+            assertThat("future date under minimum range", future.getTime(), greaterThan(now.getTime() + 4000));
         }
     }
 
@@ -48,8 +48,8 @@ public class DateAndTimeTest extends AbstractFakerTest {
         for (int i = 0; i < 1000; i++) {
             Date past = faker.date().past(5, 4, TimeUnit.SECONDS);
             assertThat("future date", past.getTime(), lessThan(now.getTime()));
-            assertThat("past date over range", past.getTime(), greaterThan(now.getTime() - 5001));
-            assertThat("past date under minimum range", past.getTime(), lessThan(now.getTime() - 3999));
+            assertThat("past date over range", past.getTime(), greaterThan(now.getTime() - 5000));
+            assertThat("past date under minimum range", past.getTime(), lessThan(now.getTime() - 4000));
         }
     }
 


### PR DESCRIPTION
Useful when we want a date in the future, specifying a minimum amount of time (like for a renewal date, where someone could want at least 30 days in the future, but 60 days maximum)