### PR TITLE
Fix random failure of genre() in MusicTest

### DIFF
--- a/src/test/java/com/github/javafaker/MusicTest.java
+++ b/src/test/java/com/github/javafaker/MusicTest.java
@@ -24,6 +24,6 @@ public class MusicTest extends AbstractFakerTest {
 
     @Test
     public void genre() {
-        assertThat(faker.music().genre(), matchesRegularExpression("\\w+ ?\\w+"));
+        assertThat(faker.music().genre(), matchesRegularExpression("[[ -]?\\w+]+"));
     }
 }


### PR DESCRIPTION
The regex for genre() method in MusicTest could not cover all the values of genre in en.yml, thus this test randomly fails (when it meets 'Rock and roll', 'Hip-Hop' etc).
I try to fix this random failure by modifying the regex of the matcher.