### PR TITLE
Fix abbreviation for Osten

### DIFF
--- a/src/main/resources/de.yml
+++ b/src/main/resources/de.yml
@@ -34,7 +34,7 @@ de:
     compass:
       cardinal:
         word: ['Norden', 'Osten', 'Süden', 'Westen']
-        abbreviation:  ['N', 'E', 'S', 'W']
+        abbreviation:  ['N', 'O', 'S', 'W']
         azimuth:  ['0', '90', '180', '270']
       ordinal:
         word:  ['Nordosten', 'Südosten', 'Südwesten', 'Nordwesten']


### PR DESCRIPTION
Osten does not start with an E!