### PR TITLE
New Android Studio, also new Gradle versions problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'com.github.javafaker', name: 'javafaker', version: '0.16'
+    implementation group: 'com.github.javafaker', name: 'javafaker', version: '0.16'
 }
 
 ```


### PR DESCRIPTION
I am using android studio with the bellow properties:

android studio version: 3.3
gradle version: 4.10.1
android plugin version: 3.3.0


1. > When I add this dependency to the build.gradle file like as bellow :

```
repositories {
    mavenCentral()
}

dependencies {
    testCompile group: 'com.github.javafaker', name: 'javafaker', version: '0.16'
}
```

2. > The project was synced but, in the each java file that I wanted to use the Faker,
    > the project didn't know the Faker class.