### PR TITLE
Add a convenient way to get USER_AGENT values and add new fake user_agent values, see issue #336

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -297,4 +297,47 @@ public class Internet {
     private <T> T random(T[] src) {
         return src[faker.random().nextInt(src.length)];
     }
+
+    public String userAgent(USER_AGENT userAgent){
+        USER_AGENT agent = userAgent;
+
+        if(agent == null) {
+            agent = USER_AGENT.any();
+        }
+
+        String userAgentKey = "internet.user_agent." + agent.toString();
+        return faker.fakeValuesService().resolve(userAgentKey, this, faker);
+    }
+
+    public String userAgentAny(){
+        return userAgent(null);
+    }
+
+    public enum USER_AGENT {
+        AOL("aol"),
+        CHROME("chrome"),
+        FIREFOX("firefox"),
+        INTERNET_EXPLORER("internet_explorer"),
+        NETSCAPE("netscape"),
+        OPERA("opera"),
+        SAFARI("safari");
+
+        //Browser's name in corresponding yaml (internet.yml) file.
+        private String browserName;
+
+        USER_AGENT(String browserName){
+            this.browserName = browserName;
+        }
+
+        private static USER_AGENT any(){
+            USER_AGENT[] agents = USER_AGENT.values();
+            int randomIndex = (int)(Math.random() * agents.length);
+            return agents[randomIndex];
+        }
+
+        @Override
+        public String toString(){
+            return browserName;
+        }
+    }
 }

--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -298,22 +298,22 @@ public class Internet {
         return src[faker.random().nextInt(src.length)];
     }
 
-    public String userAgent(USER_AGENT userAgent){
-        USER_AGENT agent = userAgent;
+    public String userAgent(UserAgent userAgent) {
+        UserAgent agent = userAgent;
 
         if(agent == null) {
-            agent = USER_AGENT.any();
+            agent = UserAgent.any();
         }
 
         String userAgentKey = "internet.user_agent." + agent.toString();
         return faker.fakeValuesService().resolve(userAgentKey, this, faker);
     }
 
-    public String userAgentAny(){
+    public String userAgentAny() {
         return userAgent(null);
     }
 
-    public enum USER_AGENT {
+    public enum UserAgent {
         AOL("aol"),
         CHROME("chrome"),
         FIREFOX("firefox"),
@@ -325,18 +325,18 @@ public class Internet {
         //Browser's name in corresponding yaml (internet.yml) file.
         private String browserName;
 
-        USER_AGENT(String browserName){
+        UserAgent(String browserName) {
             this.browserName = browserName;
         }
 
-        private static USER_AGENT any(){
-            USER_AGENT[] agents = USER_AGENT.values();
+        private static UserAgent any() {
+            UserAgent[] agents = UserAgent.values();
             int randomIndex = (int)(Math.random() * agents.length);
             return agents[randomIndex];
         }
 
         @Override
-        public String toString(){
+        public String toString() {
             return browserName;
         }
     }

--- a/src/main/resources/en/internet.yml
+++ b/src/main/resources/en/internet.yml
@@ -10,16 +10,79 @@ en:
       user_agent:
         aol:
           - Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7; AOLBuild 4343.19; Windows NT 6.1; WOW64; Trident/5.0; FunWebProducts)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; SV1)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; SV1; FunWebProducts; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 7.0; AOL 9.0; Windows NT 5.1; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows 98)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; .NET CLR 1.0.3705)
+          - Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.1; SV1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0)
         chrome:
           - Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36
+          - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36
+          - Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36
+          - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36
+          - Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36
+          - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
+          - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36
+          - Mozilla/5.0 (Windows NT 5.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36
+          - Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36
+          - Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36
         firefox:
           - Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0
+          - Mozilla/5.0 (Windows NT 5.1; rv:36.0) Gecko/20100101 Firefox/36.0
+          - Mozilla/5.0 (Windows NT 5.1; rv:33.0) Gecko/20100101 Firefox/33.0
+          - Mozilla/5.0 (Windows NT 10.0; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0
+          - Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0
+          - Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0
+          - Mozilla/5.0 (Windows NT 5.1; rv:7.0.1) Gecko/20100101 Firefox/7.0.1
+          - Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/54.0
+          - Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1
+          - Mozilla/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko/20100101 Firefox/18.0
         internet_explorer:
           - Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
+          - Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
+          - Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727)
+          - Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1; 125LA; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022)
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)
+          - Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)
         netscape:
           - Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285
+          - Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)
+          - Mozilla/4.0 (compatible; Win32; WinHttp.WinHttpRequest.5)
+          - Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/help/robots)
+          - Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7.2) Gecko/20040804 Netscape/7.2 (ax)
+          - Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)
+          - Mozilla/5.001 (windows; U; NT4.0; en-US; rv:1.0) Gecko/25250101
+          - Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.0.2) Gecko/20030208 Netscape/7.02
+          - Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.11) Gecko GranParadiso/3.0.11
+          - Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201
         opera:
           - Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16
+          - Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.18
+          - Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 OPR/43.0.2442.991
+          - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 OPR/56.0.3051.52
+          - Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 OPR/36.0.2130.32
+          - Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 OPR/43.0.2442.991
+          - Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14
+          - Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36 OPR/42.0.2393.94
+          - Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3198.0 Safari/537.36 OPR/49.0.2711.0
+          - Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36 OPR/42.0.2393.94
         safari:
           - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A
+          - Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1
+          - Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-en) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4
+          - Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+          - Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1
+          - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15
+          - Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.0 Mobile/14G60 Safari/602.1
+          - Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+          - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.59.10 (KHTML, like Gecko) Version/5.1.9 Safari/534.59.10
+          - Mozilla/5.0 (iPad; CPU OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13G36 Safari/601.1
 

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -280,13 +280,12 @@ public class InternetTest extends AbstractFakerTest {
 
     @Test
     public void testUserAgent() {
-        Internet.USER_AGENT[] agents = Internet.USER_AGENT.values();
-        for(Internet.USER_AGENT agent : agents){
-            assertThat(faker.internet().userAgent(agent), IsNot.not(isEmptyOrNullString()));
-            assertThat(faker.resolve("internet.user_agent." + agent.toString()), IsNot.not(isEmptyOrNullString()));
+        Internet.UserAgent[] agents = Internet.UserAgent.values();
+        for(Internet.UserAgent agent : agents) {
+            assertThat(faker.internet().userAgent(agent), not(isEmptyOrNullString()));
         }
 
         //Test faker.internet().userAgentAny() for random user_agent retrieval.
-        assertThat(faker.internet().userAgentAny(), IsNot.not(isEmptyOrNullString()));
+        assertThat(faker.internet().userAgentAny(), not(isEmptyOrNullString()));
     }
 }

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 import java.util.List;
@@ -275,5 +276,17 @@ public class InternetTest extends AbstractFakerTest {
         assertThat(f.internet().emailAddress(), not(isEmptyOrNullString()));
         assertThat(f.internet().safeEmailAddress(), not(isEmptyOrNullString()));
         assertThat(f.internet().url(), not(isEmptyOrNullString()));
+    }
+
+    @Test
+    public void testUserAgent() {
+        Internet.USER_AGENT[] agents = Internet.USER_AGENT.values();
+        for(Internet.USER_AGENT agent : agents){
+            assertThat(faker.internet().userAgent(agent), IsNot.not(isEmptyOrNullString()));
+            assertThat(faker.resolve("internet.user_agent." + agent.toString()), IsNot.not(isEmptyOrNullString()));
+        }
+
+        //Test faker.internet().userAgentAny() for random user_agent retrieval.
+        assertThat(faker.internet().userAgentAny(), IsNot.not(isEmptyOrNullString()));
     }
 }


### PR DESCRIPTION
**Added a way to access user_agent values using method calls through `faker.internet()` instead of resolving them through `faker.resolve(...)`.**
Example:
`faker.internet().userAgent(USER_AGENT.CHROME); //returns a CHROME user_agent value.`

**Also, added a way to get a random user_agent value without pre-selecting of browser vendor.**
Example:
`faker.internet().userAgentAny(); //returns a random user_agent value.`

**Increased the number of user_agent values in `internet.yml` file to 10 value for each browser**.