### PR TITLE
Add digit constraint for passwords, issue #360

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -110,6 +110,10 @@ public class Internet {
         return password(8, 16);
     }
 
+    public String password(boolean includeDigit) {
+        return password(8, 16, false, false, includeDigit);
+    }
+
     public String password(int minimumLength, int maximumLength) {
         return password(minimumLength, maximumLength, false);
     }
@@ -119,15 +123,19 @@ public class Internet {
     }
 
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
+        return password(minimumLength, maximumLength, includeUppercase, includeSpecial, true);
+    }
+
+    public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
         if (includeSpecial) {
-            char[] password = faker.lorem().characters(minimumLength, maximumLength, includeUppercase).toCharArray();
+            char[] password = faker.lorem().characters(minimumLength, maximumLength, includeUppercase, includeDigit).toCharArray();
             char[] special = new char[]{'!', '@', '#', '$', '%', '^', '&', '*'};
             for (int i = 0; i < faker.random().nextInt(minimumLength); i++) {
                 password[faker.random().nextInt(password.length)] = special[faker.random().nextInt(special.length)];
             }
             return new String(password);
         } else {
-            return faker.lorem().characters(minimumLength, maximumLength, includeUppercase);
+            return faker.lorem().characters(minimumLength, maximumLength, includeUppercase, includeDigit);
         }
     }
     

--- a/src/main/java/com/github/javafaker/Lorem.java
+++ b/src/main/java/com/github/javafaker/Lorem.java
@@ -39,17 +39,32 @@ public class Lorem {
         return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase);
     }
 
+    public String characters(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeDigit) {
+        return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase, includeDigit);
+    }
+
     public String characters(int fixedNumberOfCharacters) {
         return characters(fixedNumberOfCharacters, false);
     }
 
     public String characters(int fixedNumberOfCharacters, boolean includeUppercase) {
+        return characters(fixedNumberOfCharacters, includeUppercase, true);
+    }
+
+    public String characters(int fixedNumberOfCharacters, boolean includeUppercase, boolean includeDigit) {
         if (fixedNumberOfCharacters < 1) {
             return "";
         }
         char[] buffer = new char[fixedNumberOfCharacters];
         for (int i = 0; i < buffer.length; i++) {
-            char randomCharacter = characters[faker.random().nextInt(characters.length)];
+            char randomCharacter;
+
+            if (includeDigit) {
+                randomCharacter = characters[faker.random().nextInt(characters.length)];
+            } else {
+                randomCharacter = letters[faker.random().nextInt(letters.length)];
+            }
+
             if (includeUppercase && faker.bool().bool()) {
                 randomCharacter = Character.toUpperCase(randomCharacter);
             }
@@ -145,15 +160,17 @@ public class Lorem {
 
     static {
         StringBuilder builder = new StringBuilder(36);
-        for (char number = '0'; number <= '9'; number++) {
-            builder.append(number);
-        }
         for (char character = 'a'; character <= 'z'; character++) {
             builder.append(character);
+        }
+        letters = builder.toString().toCharArray();
+        for (char number = '0'; number <= '9'; number++) {
+            builder.append(number);
         }
         characters = builder.toString().toCharArray();
     }
 
+    private static final char[] letters;
     private static final char[] characters;
 
 }

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -125,6 +125,12 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
+    public void testPasswordIncludeDigit() {
+        assertThat(faker.internet().password(), matchesRegularExpression("[a-z\\d]{8,16}"));
+        assertThat(faker.internet().password(false), matchesRegularExpression("[a-z]{8,16}"));
+    }
+
+    @Test
     public void testPasswordMinLengthMaxLength() {
         assertThat(faker.internet().password(10, 25), matchesRegularExpression("[a-z\\d]{10,25}"));
     }
@@ -140,6 +146,14 @@ public class InternetTest extends AbstractFakerTest {
         assertThat(faker.internet().password(10, 25, false, false), matchesRegularExpression("[a-z\\d]{10,25}"));
         assertThat(faker.internet().password(10, 25, false, true), matchesRegularExpression("[a-z\\d!@#$%^&*]{10,25}"));
         assertThat(faker.internet().password(10, 25, true, true), matchesRegularExpression("[a-zA-Z\\d!@#$%^&*]{10,25}"));
+    }
+
+    @Test
+    public void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecialIncludeDigit() {
+        assertThat(faker.internet().password(10, 25, false, false, false), matchesRegularExpression("[a-z]{10,25}"));
+        assertThat(faker.internet().password(10, 25, false, true, true), matchesRegularExpression("[a-z\\d!@#$%^&*]{10,25}"));
+        assertThat(faker.internet().password(10, 25, true, true, false), matchesRegularExpression("[a-zA-Z!@#$%^&*]{10,25}"));
+        assertThat(faker.internet().password(10, 25, true, true, true), matchesRegularExpression("[a-zA-Z\\d!@#$%^&*]{10,25}"));
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/LoremTest.java
+++ b/src/test/java/com/github/javafaker/LoremTest.java
@@ -75,6 +75,12 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
+    public void testCharactersMinimumMaximumLengthIncludeUppercaseIncludeDigit() {
+        assertThat(faker.lorem().characters(1, 10, false, false), matchesRegularExpression("[a-zA-Z]{1,10}"));
+        assertThat(faker.lorem().characters(1, 10, true, true), matchesRegularExpression("[a-zA-Z\\d]{1,10}"));
+    }
+
+    @Test
     public void testSentence() {
         assertThat(faker.lorem().sentence(), matchesRegularExpression("(\\w+\\s?){4,10}\\."));
     }


### PR DESCRIPTION
Added digit constraints for password generations. Every existing method defaults to "true" for including digits. Exclusion of digits must be explicitly passed as a boolean parameter.

`Internet i = new Faker().internet();`
`System.out.println(i.password(8, 16, false, false));  // Defaults to True => 37fy9bv225`
`System.out.println(i.password(8, 16, false, false, false));  // Exclusion of digits => srklamzltawc`
`System.out.println(i.password()); // Defaults to True => 4lt1juph03hwzq7`
`System.out.println(i.password(true)); //Explicit True => 7dfsikm3aalbq2v`
`System.out.println(i.password(false)); // No digits => irrlhcerfezp`