### PR TITLE
Fix intermittent failing tests

### DIFF
--- a/src/test/java/com/github/javafaker/CommerceTest.java
+++ b/src/test/java/com/github/javafaker/CommerceTest.java
@@ -11,6 +11,10 @@ public class CommerceTest extends AbstractFakerTest {
 
     private static final char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
 
+    private static final String CAPITALIZED_WORD_REGEX = "[A-Z][a-z]+";
+
+    private static final String PROMOTION_CODE_REGEX = CAPITALIZED_WORD_REGEX + "(-" + CAPITALIZED_WORD_REGEX + ")*";
+
     @Test
     public void testColor() {
         assertThat(faker.commerce().color(), matchesRegularExpression("(\\w+ ?){1,2}"));
@@ -43,11 +47,11 @@ public class CommerceTest extends AbstractFakerTest {
 
     @Test
     public void testPromotionCode() {
-        assertThat(faker.commerce().promotionCode(), matchesRegularExpression("[A-Z][a-z]+[A-Z][a-z]+\\d{6}"));
+        assertThat(faker.commerce().promotionCode(), matchesRegularExpression(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{6}"));
     }
 
     @Test
     public void testPromotionCodeDigits() {
-        assertThat(faker.commerce().promotionCode(3), matchesRegularExpression("[A-Z][a-z]+[A-Z][a-z]+\\d{3}"));
+        assertThat(faker.commerce().promotionCode(3), matchesRegularExpression(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{3}"));
     }
 }

--- a/src/test/java/com/github/javafaker/CountryTest.java
+++ b/src/test/java/com/github/javafaker/CountryTest.java
@@ -28,7 +28,7 @@ public class CountryTest extends AbstractFakerTest {
 
     @Test
     public void testCapital() {
-        assertThat(faker.country().capital(), matchesRegularExpression("([\\w-]+ ?)+"));
+        assertThat(faker.country().capital(), matchesRegularExpression("([\\w'-]+ ?)+"));
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/WitcherTest.java
+++ b/src/test/java/com/github/javafaker/WitcherTest.java
@@ -29,7 +29,7 @@ public class WitcherTest extends AbstractFakerTest {
     
     @Test
     public void testQuote() {
-        assertThat(faker.witcher().quote(), matchesRegularExpression("[A-Za-z0-9 …\\?\\!\\.’',]+"));
+        assertThat(faker.witcher().quote(), matchesRegularExpression("[-A-Za-z0-9 —;…\\?\\!\\.’‘'”“,\\[\\]]+"));
     }
     
     @Test


### PR DESCRIPTION
by supporting words with dash like "First-Class" in the regex and adding missing characters to few regexes 