### PR TITLE
Add hex value generation, both for as color and as random, see issue #282

### DIFF
--- a/src/main/java/com/github/javafaker/Color.java
+++ b/src/main/java/com/github/javafaker/Color.java
@@ -10,4 +10,15 @@ public class Color {
     public String name() {
         return faker.fakeValuesService().resolve("color.name", this, faker);
     }
+
+    public String hex() {
+        return hex(false);
+    }
+
+    public String hex(boolean excludeHashSign) {
+        String hexString = faker.random().hex(6);
+        if(excludeHashSign)
+            return hexString;
+        return "#" + hexString;
+    }
 }

--- a/src/main/java/com/github/javafaker/Color.java
+++ b/src/main/java/com/github/javafaker/Color.java
@@ -12,13 +12,13 @@ public class Color {
     }
 
     public String hex() {
-        return hex(false);
+        return hex(true);
     }
 
-    public String hex(boolean excludeHashSign) {
+    public String hex(boolean includeHashSign) {
         String hexString = faker.random().hex(6);
-        if(excludeHashSign)
-            return hexString;
-        return "#" + hexString;
+        if(includeHashSign)
+            return "#" + hexString;
+        return hexString;
     }
 }

--- a/src/main/java/com/github/javafaker/service/RandomService.java
+++ b/src/main/java/com/github/javafaker/service/RandomService.java
@@ -4,12 +4,7 @@ import java.util.Random;
 
 public class RandomService {
     private static final Random SHARED_RANDOM = new Random();
-    private static final char[] hexValues;
     private final Random random;
-
-    static {
-        hexValues = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-    }
 
     /**
      * Uses a default shared random.
@@ -65,6 +60,7 @@ public class RandomService {
     }
 
     public String hex(int length) {
+        char[] hexValues = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
         StringBuilder hexString = new StringBuilder();
         for(int i = 0; i < length; i++) {
             hexString.append(hexValues[nextInt(hexValues.length)]);

--- a/src/main/java/com/github/javafaker/service/RandomService.java
+++ b/src/main/java/com/github/javafaker/service/RandomService.java
@@ -67,7 +67,7 @@ public class RandomService {
     public String hex(int length) {
         StringBuilder hexString = new StringBuilder();
         for(int i = 0; i < length; i++) {
-            hexString.append(hexValues[nextInt(16)]);
+            hexString.append(hexValues[nextInt(hexValues.length)]);
         }
         return hexString.toString();
     }

--- a/src/main/java/com/github/javafaker/service/RandomService.java
+++ b/src/main/java/com/github/javafaker/service/RandomService.java
@@ -4,7 +4,12 @@ import java.util.Random;
 
 public class RandomService {
     private static final Random SHARED_RANDOM = new Random();
+    private static final char[] hexValues;
     private final Random random;
+
+    static {
+        hexValues = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    }
 
     /**
      * Uses a default shared random.
@@ -53,5 +58,17 @@ public class RandomService {
 
     public Integer nextInt(int min, int max) {
         return random.nextInt((max - min) + 1) + min;
+    }
+
+    public String hex() {
+        return hex(8);
+    }
+
+    public String hex(int length) {
+        StringBuilder hexString = new StringBuilder();
+        for(int i = 0; i < length; i++) {
+            hexString.append(hexValues[nextInt(16)]);
+        }
+        return hexString.toString();
     }
 }

--- a/src/test/java/com/github/javafaker/ColorTest.java
+++ b/src/test/java/com/github/javafaker/ColorTest.java
@@ -11,4 +11,14 @@ public class ColorTest extends AbstractFakerTest {
     public void testName() {
         assertThat(faker.color().name(), matchesRegularExpression("(\\w+ ?){1,2}"));
     }
+
+    @Test
+    public void testHex() {
+        assertThat(faker.color().hex(), matchesRegularExpression("^#[0-9A-F]{6}$"));
+    }
+
+    @Test
+    public void testHexNoHashSign() {
+        assertThat(faker.color().hex(true), matchesRegularExpression("^[0-9A-F]{6}$"));
+    }
 }

--- a/src/test/java/com/github/javafaker/ColorTest.java
+++ b/src/test/java/com/github/javafaker/ColorTest.java
@@ -19,6 +19,6 @@ public class ColorTest extends AbstractFakerTest {
 
     @Test
     public void testHexNoHashSign() {
-        assertThat(faker.color().hex(true), matchesRegularExpression("^[0-9A-F]{6}$"));
+        assertThat(faker.color().hex(false), matchesRegularExpression("^[0-9A-F]{6}$"));
     }
 }

--- a/src/test/java/com/github/javafaker/service/RandomServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/RandomServiceTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 
+import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.CombinableMatcher.both;
@@ -61,5 +62,10 @@ public class RandomServiceTest extends AbstractFakerTest {
         for (int i = 1; i < 100; i++) {
             assertThat(randomService.nextInt(-5, 5), both(lessThanOrEqualTo(5)).and(greaterThanOrEqualTo(-5)));
         }
+    }
+
+    @Test
+    public void testHex() {
+        assertThat(faker.random().hex(8), matchesRegularExpression("^[0-9A-F]{8}$"));
     }
 }

--- a/src/test/java/com/github/javafaker/service/RandomServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/RandomServiceTest.java
@@ -66,6 +66,6 @@ public class RandomServiceTest extends AbstractFakerTest {
 
     @Test
     public void testHex() {
-        assertThat(faker.random().hex(8), matchesRegularExpression("^[0-9A-F]{8}$"));
+        assertThat(randomService.hex(8), matchesRegularExpression("^[0-9A-F]{8}$"));
     }
 }


### PR DESCRIPTION
Added a way to generate hex string from `faker.random(int length) ` and `faker.color().hex()`, related to issue #282.
**Example usages:**

```
Faker faker = new Faker(); //
System.out.println(faker.random().hex());  // 768AB21E
System.out.println(faker.random().hex(4)); // 820E
System.out.println(faker.color().hex()); // #F78DFE
System.out.println(faker.color().hex(false)); // DC095B No "#" sign.
```

