### PR TITLE
Update arguments parsing from expressions

### DIFF
--- a/src/main/java/com/github/javafaker/service/FakeValuesService.java
+++ b/src/main/java/com/github/javafaker/service/FakeValuesService.java
@@ -22,7 +22,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FakeValuesService {
-    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#\\{([a-z0-9A-Z_.]+)\\s?(?:'([^']+)')?(?:,'([^']+)')*\\}");
+
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#\\{([a-z0-9A-Z_.]+)\\s?((?:,?'([^']+)')*)\\}");
+    private static final Pattern EXPRESSION_ARGUMENTS_PATTERN = Pattern.compile("(?:'(.*?)')");
 
     private final Logger log = Logger.getLogger("faker");
 
@@ -345,9 +347,11 @@ public class FakeValuesService {
         while (matcher.find()) {
             final String escapedDirective = matcher.group(0);
             final String directive = matcher.group(1);
+            final String arguments = matcher.group(2);
+            final Matcher argsMatcher = EXPRESSION_ARGUMENTS_PATTERN.matcher(arguments);
             List<String> args = new ArrayList<String>();
-            for (int i = 2; i < matcher.groupCount() + 1 && matcher.group(i) != null; i++) {
-                args.add(matcher.group(i));
+            while (argsMatcher.find()) {
+                args.add(argsMatcher.group(1));
             }
 
             // resolve the expression and reprocess it to handle recursive templates

--- a/src/test/java/com/github/javafaker/LoremTest.java
+++ b/src/test/java/com/github/javafaker/LoremTest.java
@@ -1,12 +1,15 @@
 package com.github.javafaker;
 
 import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class LoremTest extends AbstractFakerTest {
@@ -71,7 +74,7 @@ public class LoremTest extends AbstractFakerTest {
 
     @Test
     public void testCharactersMinimumMaximumLengthIncludeUppercase() {
-        assertThat(faker.lorem().characters(1, 10), matchesRegularExpression("[a-zA-Z\\d]{1,10}"));
+        assertThat(faker.lorem().characters(1, 10, true), matchesRegularExpression("[a-zA-Z\\d]{1,10}"));
     }
 
     @Test
@@ -100,4 +103,8 @@ public class LoremTest extends AbstractFakerTest {
         assertThat(faker.lorem().sentence(10, 0), matchesRegularExpression("(\\w+\\s?){10}\\."));
     }
 
+    @Test
+    public void testWords() {
+        assertThat(faker.lorem().words(), hasSize(greaterThanOrEqualTo(1)));
+    }
 }

--- a/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
@@ -258,6 +258,13 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         assertThat( date.getTime(), lessThan( now.getTime() ));
     }
 
+    @Test
+    public void expressionWithFourArguments() throws ParseException {
+
+        assertThat(fakeValuesService.expression("#{Internet.password '5','8','true','true'}", faker),
+            matchesRegularExpression("[\\w\\d\\!%#$@_\\^&\\*]{5,8}"));
+    }
+
     /**
      * Two things are important here:
      * 1) the message in the exception should be USEFUL


### PR DESCRIPTION
There was a trouble to execute expressions with more than 2 args like this
#{Number.randomDouble '2','1','1000'}
Pattern
#\\{([a-z0-9A-Z_.]+)\\s?(?:'([^']+)')?(?:,'([^']+)')*}
 determinants just the last one match for group (?:,'([^']+)')*, as a result middle args are missed and wrong directive is built