### PR TITLE
Add Brazilian CPF identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Fakers
 * Beer
 * Book
 * Bool
-* Brazilian CPF identifier
+* BrCpfIdNumber (Brazilian CPF identifier)
 * Business
 * ChuckNorris
 * Cat

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Fakers
 * Beer
 * Book
 * Bool
+* Brazilian CPF identifier
 * Business
 * ChuckNorris
 * Cat

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -8,9 +8,9 @@ import org.apache.commons.lang3.ArrayUtils;
 import com.github.javafaker.Faker;
 
 /**
- * Generate both valid and invalid Brazilian CPF identification number.
+ * Generate both valid and invalid Brazilian CPF identification numbers.
  * 
- * For more information about CPF please visit
+ * For more information about CPF please check
  * https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas
  * 
  * The validation numbers algorithm was implemented following instructions
@@ -155,7 +155,7 @@ public class BrCpfIdNumber {
 		return cpfStringBuilder.toString();
 	}
 
-	protected int[] calculateVerifierDigits(int[] inputDigits) {
+	private int[] calculateVerifierDigits(int[] inputDigits) {
 
 		int[] invertedInputDigits = Arrays.copyOf(inputDigits, inputDigits.length);
 

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -7,29 +7,50 @@ import com.github.javafaker.Faker;
 public class BrCpfIdNumber {
 
 	private static final int INPUT_DIGITS_LENGTH = 9;
-	
+
 	private static final int VERIFIER_DIGITS_LENGTH = 2;
-	
+
 	private static final String CPF_FORMAT_PATTERN = "###.###.###-##";
 
-	public String getValidCpf(Faker faker) {
+	public String getValidFormattedCpf(Faker faker) {
 
+		int[] cpfDigits = retrieveCpfDigits(faker);
+
+		return convertAsFormattedString(cpfDigits);
+	}
+
+	public String getValidUnformattedCpf(Faker faker) {
+
+		int[] cpfDigits = retrieveCpfDigits(faker);
+
+		return convertAsUnformattedString(cpfDigits);
+	}
+
+	private int[] retrieveCpfDigits(Faker faker) {
 		int[] inputDigits = createInputDigits(faker);
 
 		int[] verifierDigits = calculateVerifierDigits(inputDigits);
 
-		int[] cpfDigits = organizeCpfDigits(inputDigits, verifierDigits);
-
-		return formatAsString(cpfDigits);
+		return organizeCpfDigits(inputDigits, verifierDigits);
 	}
 
-	private String formatAsString(int[] cpfDigits) {
+	private String convertAsFormattedString(int[] cpfDigits) {
 		String cpf = CPF_FORMAT_PATTERN;
 
 		for (int cpfDigit : cpfDigits) {
 			cpf = cpf.replaceFirst("#", Integer.toString(cpfDigit));
 		}
 		return cpf;
+	}
+
+	private String convertAsUnformattedString(int[] cpfDigits) {
+		StringBuilder cpfStringBuilder = new StringBuilder();
+
+		for (int cpfDigit : cpfDigits) {
+			cpfStringBuilder.append(cpfDigit);
+		}
+
+		return cpfStringBuilder.toString();
 	}
 
 	private int[] organizeCpfDigits(int[] inputDigits, int[] verifierDigits) {

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -27,46 +27,46 @@ public class BrCpfIdNumber {
 
 	public String getValidFormattedCpf(Faker faker) {
 
-		int[] cpfDigits = retrieveCpfDigits(faker);
+		int[] cpfDigits = createCpfDigits(faker);
 
 		return convertAsFormattedString(cpfDigits);
 	}
 
 	public String getValidUnformattedCpf(Faker faker) {
 
-		int[] cpfDigits = retrieveCpfDigits(faker);
+		int[] cpfDigits = createCpfDigits(faker);
 
 		return convertAsUnformattedString(cpfDigits);
 	}
 
 	public String getInvalidFormattedCpf(Faker faker) {
 
-		int[] cpfDigits = retrieveInvalidCpfDigits(faker);
+		int[] cpfDigits = createInvalidCpfDigits(faker);
 
 		return convertAsFormattedString(cpfDigits);
 	}
 
 	public String getInvalidUnformattedCpf(Faker faker) {
 
-		int[] cpfDigits = retrieveInvalidCpfDigits(faker);
+		int[] cpfDigits = createInvalidCpfDigits(faker);
 
 		return convertAsUnformattedString(cpfDigits);
 	}
 
-	private int[] retrieveCpfDigits(Faker faker) {
+	private int[] createCpfDigits(Faker faker) {
 		int[] inputDigits = createInputDigits(faker);
 
 		int[] verifierDigits = calculateVerifierDigits(inputDigits);
 
-		return organizeCpfDigits(inputDigits, verifierDigits);
+		return ArrayUtils.addAll(inputDigits, verifierDigits);
 	}
 
-	private int[] retrieveInvalidCpfDigits(Faker faker) {
+	private int[] createInvalidCpfDigits(Faker faker) {
 		int[] inputDigits = createInputDigits(faker);
 
 		int[] verifierDigits = calculateInvalidVerifierDigits(inputDigits, faker);
 
-		return organizeCpfDigits(inputDigits, verifierDigits);
+		return ArrayUtils.addAll(inputDigits, verifierDigits);
 	}
 
 	public boolean isValid(String cpf) {
@@ -141,13 +141,10 @@ public class BrCpfIdNumber {
 		return cpfStringBuilder.toString();
 	}
 
-	private int[] organizeCpfDigits(int[] inputDigits, int[] verifierDigits) {
+	protected int[] calculateVerifierDigits(int[] inputDigits) {
 
 		ArrayUtils.reverse(inputDigits);
-		return ArrayUtils.addAll(inputDigits, verifierDigits);
-	}
 
-	protected int[] calculateVerifierDigits(int[] inputDigits) {
 		int[] verifierDigits = new int[VERIFIER_DIGITS_LENGTH];
 
 		for (int index = 0; index < inputDigits.length; index++) {
@@ -160,13 +157,11 @@ public class BrCpfIdNumber {
 		verifierDigits[1] += verifierDigits[0] * 9;
 		verifierDigits[1] = (verifierDigits[1] % 11) % 10;
 
-		ArrayUtils.reverse(verifierDigits);
-
 		return verifierDigits;
 	}
 
 	protected boolean isValid(int[] cpfDigits) {
-		int[] inputDigits = Arrays.copyOfRange(cpfDigits, 0, INPUT_DIGITS_LENGTH);
+		int[] inputDigits = retrieveInputDigits(cpfDigits);
 
 		int[] cpfVerifierDigits = Arrays.copyOfRange(cpfDigits, INPUT_DIGITS_LENGTH,
 				INPUT_DIGITS_LENGTH + VERIFIER_DIGITS_LENGTH);
@@ -174,6 +169,10 @@ public class BrCpfIdNumber {
 		int[] calculatedVerifierDigits = calculateVerifierDigits(inputDigits);
 
 		return Arrays.equals(cpfVerifierDigits, calculatedVerifierDigits);
+	}
+
+	private int[] retrieveInputDigits(int[] cpfDigits) {
+		return Arrays.copyOfRange(cpfDigits, 0, INPUT_DIGITS_LENGTH);
 	}
 
 	private int[] createInputDigits(Faker faker) {

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import com.github.javafaker.Faker;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
 public class BrCpfIdNumber {
 
 	private static final int INPUT_DIGITS_LENGTH = 9;
@@ -101,7 +104,7 @@ public class BrCpfIdNumber {
 		return ArrayUtils.addAll(inputDigits, verifierDigits);
 	}
 
-	private int[] calculateVerifierDigits(int[] inputDigits) {
+	protected int[] calculateVerifierDigits(int[] inputDigits) {
 		int[] verifierDigits = new int[VERIFIER_DIGITS_LENGTH];
 
 		for (int index = 0; index < inputDigits.length; index++) {
@@ -115,6 +118,14 @@ public class BrCpfIdNumber {
 		verifierDigits[1] = (verifierDigits[1] % 11) % 10;
 
 		return verifierDigits;
+	}
+
+	protected boolean validateCPF(int[] cpf){
+		int[] firtNineNumbers = Arrays.copyOfRange(cpf,0, 8);
+		int[] lastTwoNumbers = Arrays.copyOfRange(cpf,9, 10);
+		int[] expectedLastTwoNumbers = calculateVerifierDigits(firtNineNumbers);
+		return expectedLastTwoNumbers[0] == lastTwoNumbers[0] &&
+				expectedLastTwoNumbers[1] == lastTwoNumbers[1];
 	}
 
 	private int[] createInputDigits(Faker faker) {

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -26,12 +26,54 @@ public class BrCpfIdNumber {
 		return convertAsUnformattedString(cpfDigits);
 	}
 
+	public String getInvalidFormattedCpf(Faker faker) {
+
+		int[] cpfDigits = retrieveInvalidCpfDigits(faker);
+
+		return convertAsFormattedString(cpfDigits);
+	}
+
+	public String getInvalidUnformattedCpf(Faker faker) {
+
+		int[] cpfDigits = retrieveInvalidCpfDigits(faker);
+
+		return convertAsUnformattedString(cpfDigits);
+	}
+
 	private int[] retrieveCpfDigits(Faker faker) {
 		int[] inputDigits = createInputDigits(faker);
 
 		int[] verifierDigits = calculateVerifierDigits(inputDigits);
 
 		return organizeCpfDigits(inputDigits, verifierDigits);
+	}
+
+	private int[] retrieveInvalidCpfDigits(Faker faker) {
+		int[] inputDigits = createInputDigits(faker);
+
+		int[] verifierDigits = calculateInvalidVerifierDigits(inputDigits, faker);
+
+		return organizeCpfDigits(inputDigits, verifierDigits);
+	}
+
+	private int[] calculateInvalidVerifierDigits(int[] inputDigits, Faker faker) {
+		int[] verifierDigits = calculateVerifierDigits(inputDigits);
+
+		for (int index = 0; index < verifierDigits.length; index++) {
+			verifierDigits[index] = retrieveRandomIntDifferentFrom(verifierDigits[index], faker);
+		}
+
+		return verifierDigits;
+	}
+
+	private int retrieveRandomIntDifferentFrom(int integer, Faker faker) {
+		int result;
+
+		do {
+			result = retrieveRandomDigit(faker);
+		} while (result == integer);
+
+		return result;
 	}
 
 	private String convertAsFormattedString(int[] cpfDigits) {
@@ -62,7 +104,7 @@ public class BrCpfIdNumber {
 	private int[] calculateVerifierDigits(int[] inputDigits) {
 		int[] verifierDigits = new int[VERIFIER_DIGITS_LENGTH];
 
-		for (int index = 0; index < INPUT_DIGITS_LENGTH; index++) {
+		for (int index = 0; index < inputDigits.length; index++) {
 			verifierDigits[0] += inputDigits[index] * (9 - (index % 10));
 			verifierDigits[1] += inputDigits[index] * (9 - ((index + 1) % 10));
 		}
@@ -77,9 +119,13 @@ public class BrCpfIdNumber {
 
 	private int[] createInputDigits(Faker faker) {
 		int[] inputDigits = new int[INPUT_DIGITS_LENGTH];
-		for (int index = 0; index < INPUT_DIGITS_LENGTH; index++) {
-			inputDigits[index] = faker.random().nextInt(10);
+		for (int index = 0; index < inputDigits.length; index++) {
+			inputDigits[index] = retrieveRandomDigit(faker);
 		}
 		return inputDigits;
+	}
+
+	private int retrieveRandomDigit(Faker faker) {
+		return faker.random().nextInt(10);
 	}
 }

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -142,14 +142,16 @@ public class BrCpfIdNumber {
 	}
 
 	protected int[] calculateVerifierDigits(int[] inputDigits) {
+		
+		int[] invertedInputDigits = Arrays.copyOf(inputDigits, inputDigits.length);
 
-		ArrayUtils.reverse(inputDigits);
+		ArrayUtils.reverse(invertedInputDigits);
 
 		int[] verifierDigits = new int[VERIFIER_DIGITS_LENGTH];
 
-		for (int index = 0; index < inputDigits.length; index++) {
-			verifierDigits[0] += inputDigits[index] * (9 - (index % 10));
-			verifierDigits[1] += inputDigits[index] * (9 - ((index + 1) % 10));
+		for (int index = 0; index < invertedInputDigits.length; index++) {
+			verifierDigits[0] += invertedInputDigits[index] * (9 - (index % 10));
+			verifierDigits[1] += invertedInputDigits[index] * (9 - ((index + 1) % 10));
 		}
 
 		verifierDigits[0] = (verifierDigits[0] % 11) % 10;

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -7,6 +7,20 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import com.github.javafaker.Faker;
 
+/**
+ * Generate both valid and invalid Brazilian CPF identification number.
+ * 
+ * For more information about CPF please visit
+ * https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas
+ * 
+ * The validation numbers algorithm was implemented following instructions
+ * provided by the Brazilian portuguese Wikipedia page at
+ * https://pt.wikipedia.org/wiki/Cadastro_de_pessoas_f%C3%ADsicas#Algoritmo
+ * 
+ * @author MarceloLeite2604
+ * @author EullerLisowski
+ *
+ */
 public class BrCpfIdNumber {
 
 	private static final int INPUT_DIGITS_LENGTH = 9;
@@ -142,7 +156,7 @@ public class BrCpfIdNumber {
 	}
 
 	protected int[] calculateVerifierDigits(int[] inputDigits) {
-		
+
 		int[] invertedInputDigits = Arrays.copyOf(inputDigits, inputDigits.length);
 
 		ArrayUtils.reverse(invertedInputDigits);

--- a/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/BrCpfIdNumber.java
@@ -1,0 +1,64 @@
+package com.github.javafaker.idnumbers;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.github.javafaker.Faker;
+
+public class BrCpfIdNumber {
+
+	private static final int INPUT_DIGITS_LENGTH = 9;
+	
+	private static final int VERIFIER_DIGITS_LENGTH = 2;
+	
+	private static final String CPF_FORMAT_PATTERN = "###.###.###-##";
+
+	public String getValidCpf(Faker faker) {
+
+		int[] inputDigits = createInputDigits(faker);
+
+		int[] verifierDigits = calculateVerifierDigits(inputDigits);
+
+		int[] cpfDigits = organizeCpfDigits(inputDigits, verifierDigits);
+
+		return formatAsString(cpfDigits);
+	}
+
+	private String formatAsString(int[] cpfDigits) {
+		String cpf = CPF_FORMAT_PATTERN;
+
+		for (int cpfDigit : cpfDigits) {
+			cpf = cpf.replaceFirst("#", Integer.toString(cpfDigit));
+		}
+		return cpf;
+	}
+
+	private int[] organizeCpfDigits(int[] inputDigits, int[] verifierDigits) {
+
+		ArrayUtils.reverse(inputDigits);
+		return ArrayUtils.addAll(inputDigits, verifierDigits);
+	}
+
+	private int[] calculateVerifierDigits(int[] inputDigits) {
+		int[] verifierDigits = new int[VERIFIER_DIGITS_LENGTH];
+
+		for (int index = 0; index < INPUT_DIGITS_LENGTH; index++) {
+			verifierDigits[0] += inputDigits[index] * (9 - (index % 10));
+			verifierDigits[1] += inputDigits[index] * (9 - ((index + 1) % 10));
+		}
+
+		verifierDigits[0] = (verifierDigits[0] % 11) % 10;
+
+		verifierDigits[1] += verifierDigits[0] * 9;
+		verifierDigits[1] = (verifierDigits[1] % 11) % 10;
+
+		return verifierDigits;
+	}
+
+	private int[] createInputDigits(Faker faker) {
+		int[] inputDigits = new int[INPUT_DIGITS_LENGTH];
+		for (int index = 0; index < INPUT_DIGITS_LENGTH; index++) {
+			inputDigits[index] = faker.random().nextInt(10);
+		}
+		return inputDigits;
+	}
+}

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -14,9 +14,9 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 	private static final String FORMATTED_CPF_REGEX_PATTERN = "^\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}$";
 
 	private static final Pattern FORMATTED_CPF_PATTERN = Pattern.compile(FORMATTED_CPF_REGEX_PATTERN);
-	
+
 	private static final String UNFORMATTED_CPF_REGEX_PATTERN = "^\\d{11}$";
-	
+
 	private static final Pattern UNFORMATTED_CPF_PATTERN = Pattern.compile(UNFORMATTED_CPF_REGEX_PATTERN);
 
 	private BrCpfIdNumber brCpfIdNumber;
@@ -31,10 +31,22 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 		String cpf = brCpfIdNumber.getValidFormattedCpf(faker);
 		assertTrue(FORMATTED_CPF_PATTERN.matcher(cpf).matches());
 	}
-	
+
 	@Test
 	public void testGetValidUnformattedCpf() throws Exception {
 		String cpf = brCpfIdNumber.getValidUnformattedCpf(faker);
+		assertTrue(UNFORMATTED_CPF_PATTERN.matcher(cpf).matches());
+	}
+
+	@Test
+	public void testGetInvalidFormattedCpf() throws Exception {
+		String cpf = brCpfIdNumber.getInvalidFormattedCpf(faker);
+		assertTrue(FORMATTED_CPF_PATTERN.matcher(cpf).matches());
+	}
+
+	@Test
+	public void testGetInvalidUnformattedCpf() throws Exception {
+		String cpf = brCpfIdNumber.getInvalidUnformattedCpf(faker);
 		assertTrue(UNFORMATTED_CPF_PATTERN.matcher(cpf).matches());
 	}
 

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -91,5 +91,22 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 		String cpf = "011.063.470-56";
 		assertTrue(brCpfIdNumber.isValid(cpf));
 	}
-
+	
+	@Test
+	public void testIsValidShouldReturnTrueForValidUnformattedCpf() throws Exception {
+		String cpf = "01106347056";
+		assertTrue(brCpfIdNumber.isValid(cpf));
+	}
+	
+	@Test
+	public void testIsValidShouldReturnFalseForInvalidFormattedCpf() throws Exception {
+		String cpf = "011.207.110-72";
+		assertFalse(brCpfIdNumber.isValid(cpf));
+	}
+	
+	@Test
+	public void testIsValidShouldReturnFalseForInvalidUnformattedCpf() throws Exception {
+		String cpf = "01120711072";
+		assertFalse(brCpfIdNumber.isValid(cpf));
+	}
 }

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -11,9 +11,13 @@ import com.github.javafaker.AbstractFakerTest;
 
 public class BrCpfIdNumberTest extends AbstractFakerTest {
 
-	private static final String CPF_REGEX_PATTERN = "\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}";
+	private static final String FORMATTED_CPF_REGEX_PATTERN = "^\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}$";
 
-	private static final Pattern CPF_PATTERN = Pattern.compile(CPF_REGEX_PATTERN);
+	private static final Pattern FORMATTED_CPF_PATTERN = Pattern.compile(FORMATTED_CPF_REGEX_PATTERN);
+	
+	private static final String UNFORMATTED_CPF_REGEX_PATTERN = "^\\d{11}$";
+	
+	private static final Pattern UNFORMATTED_CPF_PATTERN = Pattern.compile(UNFORMATTED_CPF_REGEX_PATTERN);
 
 	private BrCpfIdNumber brCpfIdNumber;
 
@@ -23,9 +27,15 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 	}
 
 	@Test
-	public void testGetValidCpf() throws Exception {
-		String cpf = brCpfIdNumber.getValidCpf(faker);
-		assertTrue(CPF_PATTERN.matcher(cpf).matches());
+	public void testGetValidFormattedCpf() throws Exception {
+		String cpf = brCpfIdNumber.getValidFormattedCpf(faker);
+		assertTrue(FORMATTED_CPF_PATTERN.matcher(cpf).matches());
+	}
+	
+	@Test
+	public void testGetValidUnformattedCpf() throws Exception {
+		String cpf = brCpfIdNumber.getValidUnformattedCpf(faker);
+		assertTrue(UNFORMATTED_CPF_PATTERN.matcher(cpf).matches());
 	}
 
 }

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -1,6 +1,5 @@
 package com.github.javafaker.idnumbers;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,19 +46,19 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 		String cpf = "065.154.070-41";
 		assertTrue(brCpfIdNumber.isValid(cpf));
 	}
-	
+
 	@Test
 	public void testIsValidShouldReturnTrueForValidUnformattedCpfStartingWithZero() throws Exception {
 		String cpf = "04893747002";
 		assertTrue(brCpfIdNumber.isValid(cpf));
 	}
-	
+
 	@Test
 	public void testIsValidShouldReturnFalseForInvalidFormattedCpfStartingWithZero() throws Exception {
 		String cpf = "099.972.740-59";
 		assertFalse(brCpfIdNumber.isValid(cpf));
 	}
-	
+
 	@Test
 	public void testIsValidShouldReturnFalseForInvalidUnformattedCpfStartingWithZero() throws Exception {
 		String cpf = "03360109025";
@@ -76,15 +75,6 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 	public void testIsValidShouldReturnTrueForValidUnformattedCpfStartingWithGreaterThanZero() throws Exception {
 		String cpf = "49764225004";
 		assertTrue(brCpfIdNumber.isValid(cpf));
-	}
-
-	@Test
-	public void debugDoTesteDeCima() throws Exception{
-		int[] cpf = { 4, 9, 6, 4, 2, 2, 5, 0 };
-		int[] expectedValues = {0, 4};
-
-		int[] actualValues = brCpfIdNumber.calculateVerifierDigits(cpf);
-		assertArrayEquals(expectedValues, actualValues);
 	}
 
 	@Test

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -1,0 +1,31 @@
+package com.github.javafaker.idnumbers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.javafaker.AbstractFakerTest;
+
+public class BrCpfIdNumberTest extends AbstractFakerTest {
+
+	private static final String CPF_REGEX_PATTERN = "\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}";
+
+	private static final Pattern CPF_PATTERN = Pattern.compile(CPF_REGEX_PATTERN);
+
+	private BrCpfIdNumber brCpfIdNumber;
+
+	@Before
+	public void setUp() {
+		brCpfIdNumber = new BrCpfIdNumber();
+	}
+
+	@Test
+	public void testGetValidCpf() throws Exception {
+		String cpf = brCpfIdNumber.getValidCpf(faker);
+		assertTrue(CPF_PATTERN.matcher(cpf).matches());
+	}
+
+}

--- a/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/BrCpfIdNumberTest.java
@@ -1,13 +1,14 @@
 package com.github.javafaker.idnumbers;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.regex.Pattern;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.github.javafaker.AbstractFakerTest;
+
+import static org.junit.Assert.*;
 
 public class BrCpfIdNumberTest extends AbstractFakerTest {
 
@@ -50,4 +51,41 @@ public class BrCpfIdNumberTest extends AbstractFakerTest {
 		assertTrue(UNFORMATTED_CPF_PATTERN.matcher(cpf).matches());
 	}
 
+	@Test
+	public void testValidCpfStartingWithZero() throws Exception {
+		int[] cpf = {0,8,5,3,2,5,9,4,0};
+		assertSame(brCpfIdNumber.calculateVerifierDigits(cpf)[0], 2);
+		assertSame(brCpfIdNumber.calculateVerifierDigits(cpf)[1], 6);
+	}
+
+	@Test
+	public void testValidCpfStartingWithGreaterThanZero() throws Exception {
+		int[] cpf = {9,3,7,8,5,1,4,8,0};
+		assertSame(brCpfIdNumber.calculateVerifierDigits(cpf)[0], 4);
+		assertSame(brCpfIdNumber.calculateVerifierDigits(cpf)[1], 6);
+	}
+
+	@Test
+	public void testVerifyValidCpfStartingWithZero() throws Exception {
+		int[] cpf = {0,8,5,3,2,5,9,4,0,2,6};
+		assertEquals(brCpfIdNumber.validateCPF(cpf),true);
+	}
+
+	@Test
+	public void testVerifyValidCpfStartingWithGreaterThanZero() throws Exception {
+		int[] cpf = {7,9,3,1,3,9,8,4,0,8,3};
+		assertEquals(brCpfIdNumber.validateCPF(cpf),true);
+	}
+
+	@Test
+	public void testVerifyInvalidCpfStartingWithZero() throws Exception {
+		int[] cpf = {0,0,4,6,6,7,6,4,0,6,5};
+		assertEquals(brCpfIdNumber.validateCPF(cpf),false);
+	}
+
+	@Test
+	public void testVerifyInvalidCpfStartingWithGreaterThanZero() throws Exception {
+		int[] cpf = {1,2,3,4,5,6,7,8,9,0,1};
+		assertEquals(brCpfIdNumber.validateCPF(cpf),false);
+	}
 }


### PR DESCRIPTION
Add a new faker for both valid and invalid Brazilian CPF identification.
More information about CPF can be found on [Wikipedia CPF site](https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas).