### PR TITLE
Fix TW address

### DIFF
--- a/src/main/resources/en/address.yml
+++ b/src/main/resources/en/address.yml
@@ -225,7 +225,7 @@ en:
         SE: "Sweden"
         CH: "Switzerland"
         SY: "Syrian Arab Republic"
-        TW: "Taiwan, Province Of China"
+        TW: "Taiwan"
         TJ: "Tajikistan"
         TZ: "Tanzania, United Republic Of"
         TH: "Thailand"


### PR DESCRIPTION
@codingricky 
Most Taiwanese do not think that Taiwan is part of China.
So maybe this PR can be merged.
It has a long historical debate, and can't reflect the current situation between Taiwan and China.
Similar discussion on other repository.
 [https://github.com/woocommerce/woocommerce/pull/24425](url)
 [https://github.com/mledoze/countries/issues/4](url)
 [https://github.com/Bastian/bStats/pull/99](url)
Thanks for review.