### PR TITLE
Bug fix in FakeValuesService setup

### DIFF
--- a/src/main/java/com/github/javafaker/service/FakeValuesService.java
+++ b/src/main/java/com/github/javafaker/service/FakeValuesService.java
@@ -70,7 +70,7 @@ public class FakeValuesService {
                 }
                 all.add(fakeValuesGrouping);
             } else {
-                all.add(new FakeValues(locale));
+                all.add(new FakeValues(l));
             }
         }
 


### PR DESCRIPTION
The normalized locale is never added to the chain of locales.

For fr-CA locale, the fakeValuesList will contains FakeValues with locale in this order [fr-CA, fr-CA, en]
and not the intended [fr-CA, fr, en].

To fix the issue we need to use the variable l from the chain of locales and not the locale value.