### PR TITLE
Fixed internet password when no special chars are added, while "includeSpecial" is set to true

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -130,7 +130,7 @@ public class Internet {
         if (includeSpecial) {
             char[] password = faker.lorem().characters(minimumLength, maximumLength, includeUppercase, includeDigit).toCharArray();
             char[] special = new char[]{'!', '@', '#', '$', '%', '^', '&', '*'};
-            for (int i = 0; i < faker.random().nextInt(minimumLength); i++) {
+            for (int i = 0; i <= faker.random().nextInt(minimumLength); i++) {
                 password[faker.random().nextInt(password.length)] = special[faker.random().nextInt(special.length)];
             }
             return new String(password);


### PR DESCRIPTION
Java's nextInt(int bound) 
```
Returns a pseudorandom, uniformly distributed {@code int} value
     * between 0 (inclusive) and the specified value (exclusive), drawn from
     * this random number generator's sequence.

```
Which makes this statement is not executable when nextInt returns 0, therefore no special chars are added:

```
for (int i = 0; i < faker.random().nextInt(minimumLength); i++) {
password[faker.random().nextInt(password.length)] = special[faker.random().nextInt(special.length)];
}
```