### PR TITLE
Changing the Turkish adage to its correct usage

### DIFF
--- a/src/main/resources/tr.yml
+++ b/src/main/resources/tr.yml
@@ -37,4 +37,4 @@ tr:
       title: ['Taht Oyunları', 'Maymunlar Gezegeni', 'Benim Adım Kırmızı', 'Uykuların Doğusu', 'Yılanların Öcü']
       author: "#{Name.name}"
       publisher: ['Babıali Kültür Yayıncılığı', 'İletişim Yayınları', 'Turkuvaz Kitap', 'Kaynak Yayınları']
-      quote: ['Sabır acıdır, meyvesi tatlıdır', 'Dost kara günde belli olur', 'Çıkmayan candan umit kesilmez', 'Gözden uzak olan gönülden de uzak olur.']
+      quote: ['Sabır acıdır, meyvesi tatlıdır', 'Dost kara günde belli olur', 'Çıkmamış candan umit kesilmez', 'Gözden uzak olan gönülden de uzak olur.']


### PR DESCRIPTION
Changing the working to the original turkish adage.
 Both "çıkmadık candan ümit kesilmez" and "Çıkmamış candan umit kesilmez" are valid usages but "Çıkmayan candan umit kesilmez" is not.

https://www.reddit.com/r/turkishlearning/comments/e8543h/translation_of_%C3%A7%C4%B1kmad%C4%B1k_candan_%C3%BCmit_kesilmez/
https://tr.wiktionary.org/wiki/%C3%87%C4%B1kmam%C4%B1%C5%9F_candan_%C3%BCmit_kesilmez