### PR TITLE
Correctly handle generating a password of fixed length

### DIFF
--- a/src/main/java/com/github/javafaker/Lorem.java
+++ b/src/main/java/com/github/javafaker/Lorem.java
@@ -36,11 +36,19 @@ public class Lorem {
     }
 
     public String characters(int minimumLength, int maximumLength, boolean includeUppercase) {
-        return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase);
+        if (minimumLength == maximumLength) {
+            return characters(minimumLength, includeUppercase);
+        } else {
+            return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase);
+        }
     }
 
     public String characters(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeDigit) {
-        return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase, includeDigit);
+        if (minimumLength == maximumLength) {
+            return characters(minimumLength, includeUppercase, includeDigit);
+        } else {
+            return characters(faker.random().nextInt(maximumLength - minimumLength) + minimumLength, includeUppercase, includeDigit);
+        }
     }
 
     public String characters(int fixedNumberOfCharacters) {

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class InternetTest extends AbstractFakerTest {
-
     @Test
     public void testEmailAddress() {
         String emailAddress = faker.internet().emailAddress();
@@ -112,6 +111,12 @@ public class InternetTest extends AbstractFakerTest {
     @Test
     public void testPassword() {
         assertThat(faker.internet().password(), matchesRegularExpression("[a-z\\d]{8,16}"));
+    }
+
+    @Test
+    public void testPasswordWithFixedLength() {
+        String password = Faker.instance().internet().password(32, 32, true, true, true);
+        assertThat(password.length(), is(32));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/DiUS/java-faker/issues/498

The `maximum - minimum` calculation results in calling `random.nextInt(0)`; this change adds a check for when `maximum == minimum` and avoids calling `nextInt` in that case.