### PR TITLE
Fix password randomizer for includeSpecial attr

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -130,7 +130,7 @@ public class Internet {
         if (includeSpecial) {
             char[] password = faker.lorem().characters(minimumLength, maximumLength, includeUppercase, includeDigit).toCharArray();
             char[] special = new char[]{'!', '@', '#', '$', '%', '^', '&', '*'};
-            for (int i = 0; i < faker.random().nextInt(minimumLength); i++) {
+            for (int i = 0; i < faker.random().nextInt(1, minimumLength); i++) {
                 password[faker.random().nextInt(password.length)] = special[faker.random().nextInt(special.length)];
             }
             return new String(password);


### PR DESCRIPTION
If old implementation 'faker.random().nextInt(minimumLength)' returned 0 - password will not contains special char