### PR TITLE
Fix bug #566 "en-ZA" ID number is invalid

### DIFF
--- a/src/main/java/com/github/javafaker/IdNumber.java
+++ b/src/main/java/com/github/javafaker/IdNumber.java
@@ -1,6 +1,7 @@
 package com.github.javafaker;
 
 import com.github.javafaker.idnumbers.EnIdNumber;
+import com.github.javafaker.idnumbers.EnZAIdNumber;
 import com.github.javafaker.idnumbers.SvSEIdNumber;
 
 public class IdNumber {
@@ -22,13 +23,29 @@ public class IdNumber {
         EnIdNumber enIdNumber = new EnIdNumber();
         return enIdNumber.getValidSsn(faker);
     }
-
     /**
      * Specified as #{IDNumber.valid_sv_se_ssn} in sv-SE.yml
      */
     public String validSvSeSsn() {
         SvSEIdNumber svSEIdNumber = new SvSEIdNumber();
+
         return svSEIdNumber.getValidSsn(faker);
+    }
+
+    /**
+     * Specified as #{IDNumber.valid_en_za_ssn} in en-ZA.yml
+     */
+    public String validEnZaSsn() {
+        EnZAIdNumber enZAIdNumber = new EnZAIdNumber();
+        return enZAIdNumber.getValidSsn(faker);
+    }
+
+    /**
+     * Specified as #{IDNumber.invalid_en_za_ssn} in en-ZA.yml
+     */
+    public String inValidEnZaSsn() {
+        EnZAIdNumber enZAIdNumber = new EnZAIdNumber();
+        return enZAIdNumber.getInValidSsn(faker);
     }
 
     /**
@@ -38,4 +55,5 @@ public class IdNumber {
         SvSEIdNumber svSEIdNumber = new SvSEIdNumber();
         return svSEIdNumber.getInvalidSsn(faker);
     }
+
 }

--- a/src/main/java/com/github/javafaker/idnumbers/EnZAIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/EnZAIdNumber.java
@@ -1,0 +1,107 @@
+package com.github.javafaker.idnumbers;
+
+import com.github.javafaker.Faker;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Implementation based on the definition at
+ * https://en.wikipedia.org/wiki/South_African_identity_card
+ */
+
+public class EnZAIdNumber {
+
+    private static final String[] validPattern = {"##########08#","##########18#"};
+
+    public String getValidSsn(Faker f) {
+
+        String ssn = "";
+        while (!validSsn(ssn)){
+            String pattern = getPattern(f);
+            ssn = f.numerify(pattern);
+        }
+        return ssn;
+
+    }
+
+    public String getInValidSsn(Faker f) {
+
+        String ssn = f.numerify(validPattern[f.random().nextInt(2)]);
+        while (validSsn(ssn)) {
+            String pattern = getPattern(f);
+            ssn = f.numerify(pattern);
+        }
+        return ssn;
+    }
+
+    private String getPattern(Faker faker) {
+        return validPattern[faker.random().nextInt(2)];
+    }
+
+    boolean validSsn(String ssn) {
+        if (ssn.length() != 13) {
+            return false;
+        }
+
+        try {
+            if (parseDate(ssn)) {
+                return false;
+            }
+        } catch (ParseException e) {
+            return false;
+        }
+
+        int calculatedChecksum = calculateChecksum(ssn.substring(0,12));
+        int checksum = Integer.parseInt(ssn.substring(12,13));
+        return (checksum == calculatedChecksum);
+    }
+
+    private boolean parseDate(String ssn) throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyMMdd");
+        String dateString = ssn.substring(0, 6);
+        Date date = sdf.parse(dateString);
+
+        // want to check that the parsed date is equal to the supplied data, most of the attempts will fail
+        String reversed = sdf.format(date);
+        return !reversed.equals(dateString);
+    }
+
+    private int calculateChecksum(String number) {
+
+        int totalNumber = 0;
+
+        for (int i = number.length() - 1; i >= 0; i -= 2) {
+            int tmpNumber = calculate(Integer.parseInt(String.valueOf(number.charAt(i))) * 2);
+            if (i == 0) {
+                totalNumber += tmpNumber;
+            } else {
+                totalNumber += tmpNumber + Integer.parseInt(String.valueOf(number.charAt(i - 1)));
+            }
+
+        }
+        if (totalNumber >= 0 && totalNumber < 9) {
+            return (10 - totalNumber);
+        } else {
+            String str = String.valueOf(totalNumber);
+            String s = String.valueOf(str.charAt(str.length() - 1));
+            if (Integer.parseInt(s) == 0) {
+                return 0;
+            } else {
+                return (10 - Integer.parseInt(s));
+            }
+        }
+
+    }
+
+    private static int calculate(int number){
+        String str = String.valueOf(number);
+        int total = 0;
+        for (int i = 0; i < str.length(); i++) {
+            total += Integer.parseInt(String.valueOf(str.charAt(i)));
+        }
+        return total;
+    }
+
+}

--- a/src/main/resources/en-ZA.yml
+++ b/src/main/resources/en-ZA.yml
@@ -134,10 +134,10 @@ en-ZA:
       name_with_middle:
         - "#{first_name} #{last_name} #{last_name}"
 
-    # Can produce an invalid South African ID Number
-    # (See Faker::SouthAfrica.valid_id_number for alternative)
     id_number:
-      formats: ["##########08#"]
+      valid: "#{IDNumber.valid_en_za_ssn}"
+      invalid: "#{IDNumber.invalid_en_za_ssn}"
+
     team:
       provinces: [Limpopo, Gauteng, Free State,
        North West, Northern Cape, Western Cape,

--- a/src/test/java/com/github/javafaker/idnumbers/EnZAIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/EnZAIdNumberTest.java
@@ -1,0 +1,57 @@
+package com.github.javafaker.idnumbers;
+
+import com.github.javafaker.Faker;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class EnZAIdNumberTest {
+
+
+    @Test
+    public void valid() {
+        EnZAIdNumber idNumber = new EnZAIdNumber();
+        final Faker f = new Faker(new Locale("en-ZA"));
+
+        assertThat(idNumber.validSsn(f.idNumber().valid()), is(true));
+        assertThat(idNumber.validSsn(f.idNumber().valid()), is(true));
+
+        assertThat(idNumber.validSsn("9202204720083"), is(true));
+        assertThat(idNumber.validSsn("8801235111088"), is(true));
+    }
+
+    @Test
+    public void invalid() {
+        EnZAIdNumber idNumber = new EnZAIdNumber();
+        final Faker f = new Faker(new Locale("en-ZA"));
+
+        assertThat(idNumber.validSsn(f.idNumber().invalid()), is(false));
+        assertThat(idNumber.validSsn(f.idNumber().invalid()), is(false));
+
+        assertThat(idNumber.validSsn("9202204720085"), is(false));
+        assertThat(idNumber.validSsn("foo2204720082"), is(false));
+        assertThat(idNumber.validSsn("9232454720082"), is(false));
+
+    }
+
+    @Test
+    public void testValidSsn() {
+        final Faker f = new Faker(new Locale("en-ZA"));
+        for (int i = 0; i < 100; i++) {
+            Assert.assertThat(f.idNumber().valid(), matchesRegularExpression("\\d{10}[01][8]\\d{1}"));
+        }
+    }
+
+    @Test
+    public void testInvalidSsn() {
+        final Faker f = new Faker(new Locale("en-ZA"));
+        for (int i = 0; i < 100; i++) {
+            Assert.assertThat(f.idNumber().invalid(), matchesRegularExpression("\\d{10}[01][8]\\d{1}"));
+        }
+    }
+}


### PR DESCRIPTION
ID number for Locale "en-ZA"
produces id in format is: ###-##-####
It should be: YYMMDDSSSSCAZ
[YYMMDD is birthday, SSSS is serial number and 0000-4999 is female, C is 0 or 1, A is 8, Z is check number of Luhn algorithm]

What we do:

Create class 'EnZAIdNumber' corresponding to ID number for Locale "en-ZA" region ID card, in which the ID number for Locale "en-ZA" are created and judged whether it is legal
Call the class 'EnZAIdNumber' in class IdNumber, and use the interface of ID number for Locale "en-ZA" in en-ZA.yml
Create "EnZAIdNumberTest" test file, A series of legitimacy tests for ID number for Locale "en-ZA" are added, and a series of tests for ID number for Locale "en-ZA" card format are newly built