### PR TITLE
Add Chinese ID number generation.

### DIFF
--- a/src/main/java/com/github/javafaker/IdNumber.java
+++ b/src/main/java/com/github/javafaker/IdNumber.java
@@ -2,6 +2,7 @@ package com.github.javafaker;
 
 import com.github.javafaker.idnumbers.EnIdNumber;
 import com.github.javafaker.idnumbers.SvSEIdNumber;
+import com.github.javafaker.idnumbers.ZhCNIdNumber;
 
 public class IdNumber {
     private final Faker faker;
@@ -37,5 +38,15 @@ public class IdNumber {
     public String invalidSvSeSsn() {
         SvSEIdNumber svSEIdNumber = new SvSEIdNumber();
         return svSEIdNumber.getInvalidSsn(faker);
+    }
+
+    public String zhCnSsnValid() {
+        ZhCNIdNumber zhCNIdNumber = new ZhCNIdNumber();
+        return zhCNIdNumber.getValidCN(faker);
+    }
+
+    public String zhCnSsnInValid() {
+        ZhCNIdNumber zhCNIdNumber = new ZhCNIdNumber();
+        return zhCNIdNumber.getInvalidCN(faker);
     }
 }

--- a/src/main/java/com/github/javafaker/idnumbers/ZhCNIdNumber.java
+++ b/src/main/java/com/github/javafaker/idnumbers/ZhCNIdNumber.java
@@ -1,0 +1,132 @@
+package com.github.javafaker.idnumbers;
+
+import com.github.javafaker.Faker;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ZhCNIdNumber {
+
+    private static final String[] validPatterns = {"######-####", "######+####"};
+
+    public String getValidCN(Faker f) {
+        String idNumber = "";
+        String addressNumber = getAddress(f);           //1~6
+        String birthdayNumber = getBirthday(f);         //7~14
+        String sequenceNumber = getSequenceNumber(f);   //15~17
+
+        idNumber = addressNumber + birthdayNumber + sequenceNumber;
+
+        String checkSum = calCheckSumOfId(f, idNumber);
+
+        idNumber += checkSum;   //18
+
+        return idNumber;
+    }
+
+    public String getInvalidCN(Faker f) {
+        String invalidIdNumber = f.numerify("##################");
+        while (!invalidCheck(f, invalidIdNumber)){
+            invalidIdNumber = f.numerify("##################");
+        }
+
+        return invalidIdNumber;
+    }
+
+    /* Check if the id number is invalid, if invalid, return true. */
+    boolean invalidCheck(Faker f, String invalidIdNumber) {
+        int n = invalidIdNumber.length();
+        return !calCheckSumOfId(f,
+                invalidIdNumber.substring(0, n - 1)).equals(invalidIdNumber.substring(n - 1));
+    }
+
+    /* Different province numbers in China. */
+    public List<String> provinces = Arrays.asList(
+            "11","12","13","14","15",
+            "21","22","23",
+            "31","32","33","34","35","36","37",
+            "41","42","43","44","45","46",
+            "50","51","52","53","54",
+            "61","62","63","64","65",
+            "81","82"
+    );
+
+    /* Address is made of province, city and district numbers. */
+    private String getAddress(Faker f){
+        String provinceNumber = getProvince(f);
+        String cityNumber = getCity(f);
+        String districtNumber = getDistrict(f);
+        String addressNumber = provinceNumber + cityNumber + districtNumber;
+        return addressNumber;
+
+    }
+
+    private String getProvince(Faker f){
+        int index = f.random().nextInt(provinces.size());
+        String provinceNumber = provinces.get(index);
+        return provinceNumber;
+    }
+
+    private String getCity(Faker f){
+        String cityNumber = f.numerify("##");
+        return cityNumber;
+    }
+
+    private String getDistrict(Faker f){
+        String cityNumber = f.numerify("##");
+        return cityNumber;
+    }
+
+    private String getBirthday(Faker f) {
+
+        int year = f.random().nextInt(1900, 2021);
+        int month = f.random().nextInt(1, 12);
+        int day = validDay(year, month, f);
+
+        return String.valueOf(year * 10000 + month * 100 + day);
+    }
+
+    private int validDay(int year, int month, Faker f) {
+
+        List<Integer> bigMonths = Arrays.asList(1,3,5,7,8,10,12);
+        List<Integer> smallMonths = Arrays.asList(4,6,9,11);
+
+        if (month == 2) {
+            if (year % 4 == 0) {
+                return f.random().nextInt(1, 29);
+            }
+            else return f.random().nextInt(1, 28);
+        }
+
+        else if (bigMonths.contains(month)) {
+            return f.random().nextInt(1, 31);
+        }
+        else return f.random().nextInt(1, 30);
+
+    }
+
+    public String getSequenceNumber(Faker f) {
+        String seqNumber = f.numerify("###");
+        return seqNumber;
+    }
+
+    private String calCheckSumOfId(Faker f, String idNumber) {
+        int[] weights = {7,9,10,5,8,4,2,1,6,3,7,9,10,5,8,4,2};
+        int checksum = 0;
+        int sum = 0;
+        int Y = 0;
+        try {
+            for (int i = 0;i<idNumber.length();i++){
+                sum += weights[i] * Integer.parseInt(idNumber.substring(i, i+1));
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            e.printStackTrace();
+        }
+
+        Y = sum % 11;
+        checksum = (12 - Y) % 11;
+        if (checksum == 10) return "X";
+        return String.valueOf(checksum);
+    }
+
+}

--- a/src/main/resources/zh-CN.yml
+++ b/src/main/resources/zh-CN.yml
@@ -54,3 +54,7 @@ zh-CN:
       suffix: ["理工大学", "技术大学", "艺术大学", "体育大学", "经贸大学", "农业大学", "科技大学", "大学"]
       name:
         - "#{University.prefix}#{University.suffix}"
+
+    id_number:
+      valid: "#{IDNumber.zh_cn_ssn_valid}"
+      invalid: "#{IDNumber.zh_cn_ssn_in_valid}"

--- a/src/test/java/com/github/javafaker/idnumbers/ChineseIdNumberTest.java
+++ b/src/test/java/com/github/javafaker/idnumbers/ChineseIdNumberTest.java
@@ -1,0 +1,61 @@
+package com.github.javafaker.idnumbers;
+
+import com.github.javafaker.Faker;
+import org.junit.Test;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ChineseIdNumberTest {
+
+    @Test
+    public void testChecksum() {
+        Faker f = new Faker(new Locale("zh-CN"));
+        ZhCNIdNumber zhCNIdNumber = new ZhCNIdNumber();
+
+        String idNo = f.idNumber().valid();
+        assertFalse(zhCNIdNumber.invalidCheck(f, idNo));
+    }
+
+    @Test
+    public void testProvinces() {
+        Faker f = new Faker(new Locale("zh-CN"));
+        ZhCNIdNumber zhCNIdNumber = new ZhCNIdNumber();
+
+        String idNo = f.idNumber().valid();
+        assertTrue(zhCNIdNumber.provinces.contains(idNo.substring(0,2)));
+    }
+
+    @Test
+    public void testBirthday() {
+        Faker f = new Faker(new Locale("zh-CN"));
+        ZhCNIdNumber zhCNIdNumber = new ZhCNIdNumber();
+
+        String idNo = f.idNumber().valid();
+        String birthday = idNo.substring(6, 14);
+        boolean isBirthday;
+
+        DateFormat format = new SimpleDateFormat("yyyyMMdd");
+        try {
+            format.setLenient(false);
+            Date date = format.parse(birthday);
+            isBirthday = true;
+
+        } catch (ParseException e) {
+            e.printStackTrace();
+            isBirthday = false;
+        }
+
+        assertTrue(isBirthday);
+
+    }
+
+
+
+}


### PR DESCRIPTION
Fix bug #588 No support for Chinese ID No

A simple description of this bug: The form of Chinese ID number is same as the English ssn, which should be fixed.

What we do:

We implement the generation of Chinese ID number with the specific logic and try to make the ID close to a real one. Rules including province number, birthday date, sequence number and checksum.
We develop some tests to make sure that the process of Chinese ID number generation is without errors and the ID is valid.