### PR TITLE
fix issue #626: Typo in the faker.subscription.plans variable inside es.yml

### DIFF
--- a/src/main/resources/es.yml
+++ b/src/main/resources/es.yml
@@ -87,7 +87,7 @@ es:
     music:
       instruments: ['Guitarra Eléctrica', 'Guitarra Acústica', 'Flauta', 'Trompeta', 'Clarinete', 'Violonchelo', 'Arpa', 'Xilofón', 'Armónica', 'Acordión', 'Organo', 'Piano', 'Ukelele', 'Saxofón', 'Bateria', 'Violín', 'Bajo']
     subscription:
-      plans: ["Prueba gratuita", "Basico", "Starter", "Essential", "Estudiante", Bronze", "Standard", "Silver", "Gold", "Platinum", "Profesional", "Business", "Diamond", "Premium"]
+      plans: ["Prueba gratuita", "Basico", "Starter", "Essential", "Estudiante", "Bronze", "Standard", "Silver", "Gold", "Platinum", "Profesional", "Business", "Diamond", "Premium"]
       statuses: ["Activo", "Parado", "Bloqueado", "Pendiente"]
       payment_methods: ["Tarjeta de credito", "Tarjeta de débito", "Paypal", "Efectivo", "Transferencia de dinero", "Bitcoins", "Cheque", "Apple Pay", "Google Pay", "WeChat Pay", "Alipay", "Visa Checkout"]
       subscription_terms: ["Diaria", "Semanal", "Mensual", "Anual", "Bienal", "Trienal", "Quinquenal", "De por vida"]


### PR DESCRIPTION
There is a quote character missing in one of the yml variables in es.yml.
I make a pr to promote this issue merged.