### PR TITLE
Added cell phone support for the Dutch (NL) language.

### DIFF
--- a/src/main/resources/nl.yml
+++ b/src/main/resources/nl.yml
@@ -84,6 +84,8 @@ nl:
 
     phone_number:
       formats: ["(####) ######", "##########", "06########", "06 #### ####"]
+    cell_phone:
+      formats: ["06########", "06 #### ####"]
 
     university:
       prefix: [Universiteit, Hogeschool]


### PR DESCRIPTION
The cell phone numbers that were generated in Dutch were incorrect. A Dutch cell phone starts with 06 followed by 8 digits.