### PR TITLE
Add support of methods with varargs and #{options.option ...}

### DIFF
--- a/src/main/java/com/github/javafaker/Options.java
+++ b/src/main/java/com/github/javafaker/Options.java
@@ -1,5 +1,6 @@
 package com.github.javafaker;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class Options {
@@ -17,6 +18,16 @@ public class Options {
      * @return A randomly selected element from the varargs.
      */
     public <E> E option(E... options) {
+        return options[faker.random().nextInt(options.length)];
+    }
+
+    /**
+     * Returns a random String element from an varargs.
+     *
+     * @param options The varargs to take a random element from.
+     * @return A randomly selected element from the varargs.
+     */
+    public String option(String... options) {
         return options[faker.random().nextInt(options.length)];
     }
 

--- a/src/test/java/com/github/javafaker/FakerTest.java
+++ b/src/test/java/com/github/javafaker/FakerTest.java
@@ -124,6 +124,8 @@ public class FakerTest extends AbstractFakerTest {
 
     @Test
     public void expression() {
+        assertThat(faker.expression("#{options.option 'a','b','c','d'}"), matchesRegularExpression("(a|b|c|d)"));
+        assertThat(faker.expression("#{options.option '12','345','89','54321'}"), matchesRegularExpression("(12|345|89|54321)"));
         assertThat(faker.expression("#{regexify '(a|b){2,3}'}"), matchesRegularExpression("(a|b){2,3}"));
         assertThat(faker.expression("#{regexify '\\.\\*\\?\\+'}"), matchesRegularExpression("\\.\\*\\?\\+"));
         assertThat(faker.expression("#{bothify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));


### PR DESCRIPTION
There 2 issues:
1. Current code can not resolve the code with varargs e.g. `Options.option`
2. Options does not have `option` method with `String` varargs which is implied by `FakeValuesService`

This PR adds check if there is varargs in method args and supports it, also adds `Options.option` with String varargs to make it working like
``` 
#{options.option '12','345','89','54321'}
```