### PR TITLE
Upgrade snakeyaml to 1.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
-            <classifier>android</classifier>
+            <version>1.30</version>
         </dependency>
         <dependency>
             <groupId>com.github.mifmif</groupId>


### PR DESCRIPTION
snakeyaml in v1.30 doesn't support an android classifier.