### PR TITLE
fix repetition of last name in name_with_middle for ru

### DIFF
--- a/src/main/resources/ru.yml
+++ b/src/main/resources/ru.yml
@@ -49,7 +49,8 @@ ru:
         - "#{female_first_name} #{female_middle_name} #{female_last_name}"
         - "#{female_last_name} #{female_first_name} #{female_middle_name}"
       name_with_middle:
-        - "#{first_name} #{last_name} #{last_name}"
+        - "#{male_last_name} #{male_first_name} #{male_middle_name}"
+        - "#{female_last_name} #{female_first_name} #{female_middle_name}"
 
     phone_number:
       formats: ['+7(9##)###-##-##']


### PR DESCRIPTION
When I used the library, I paid attention that the method name_with_middle return two last names instead of middle name. So I propose the fix and more convenient name_with_middle format (at least for russian-speakers).