### PR TITLE
Add out-of-support notice with a link to kotlin-faker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Notice
+
+This library is no longer actively maintained. Consider an alternative [kotlin-faker](https://github.com/serpro69/kotlin-faker) implementation.
+
+---
+
 Java Faker
 ==========
 


### PR DESCRIPTION
It very much looks like this library is no longer actively maintained. Therefore it's good to notify users of this and provide them with a more stable and supported alternative library which provides the same functionality.

Not really sure that this PR will be considered though, since it looks like most of the open recent PRs are left w/o attention from maintainers.