### PR TITLE
Added method to Internet Faker for RFC Message IDs…

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -38,6 +38,25 @@ public class Internet {
         return join(stripAccents(localPart), "@", domain);
     }
 
+    /**
+    * Generates a message-id (msg-id) valid per https://tools.ietf.org/html/rfc2822
+    *
+    * @param domain The domain name to use in the id-right part of the message-id
+    * @return A valid message id with the supplied domain
+    */
+    public String rfcMessageId(String domain) {
+        return join("<", UUID.randomUUID(), "@", domain, ">");
+    }
+
+    /**
+    * Generates a message-id (msg-id) valid per https://tools.ietf.org/html/rfc2822
+    *
+    * @return A valid message id with a faker generated domain
+    */
+    public String rfcMessageId() {
+        return rfcMessageId(domainName());
+    }
+
     public String domainName() {
         return domainWord() + "." + domainSuffix();
     }

--- a/src/test/java/com/github/javafaker/InternetTest.java
+++ b/src/test/java/com/github/javafaker/InternetTest.java
@@ -89,6 +89,18 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
+    public void testRfc2822MessageIdIsValid() {
+        String rfcMessageId = faker.internet().rfcMessageId();
+        assertThat(rfcMessageId, matchesRegularExpression("<.*@.*\\..*>"));
+    }
+
+    @Test
+    public void testRfc2822MessageIdIsValidSuppliedDomain() {
+        String rfcMessageId = faker.internet().rfcMessageId("mydomain.org");
+        assertThat(rfcMessageId, matchesRegularExpression("<.*@.*\\..*>"));
+    }
+
+    @Test
     public void testDomainName() {
         assertThat(faker.internet().domainName(), matchesRegularExpression("[a-z]+\\.\\w{2,4}"));
     }


### PR DESCRIPTION
This PR adds new methods to the Internet faker, to create RFC 2822 compliant message IDs, like this:

`<blarg@something.usually.domain.com>`

Testing done - new unit tests added to InternetTests.java