### PR TITLE
Allow some email addresses to contain single quote characters

### DIFF
--- a/src/main/java/com/github/javafaker/Internet.java
+++ b/src/main/java/com/github/javafaker/Internet.java
@@ -19,7 +19,7 @@ public class Internet {
     }
 
     public String emailAddress() {
-        return emailAddress(faker.name().username());
+        return emailAddress(faker.name().localPart());
     }
 
     public String emailAddress(String localPart) {

--- a/src/main/java/com/github/javafaker/Name.java
+++ b/src/main/java/com/github/javafaker/Name.java
@@ -129,6 +129,32 @@ public class Name {
 
         return StringUtils.deleteWhitespace(username);
     }
+
+    /**
+     * <p>
+     *     A lowercase local part of an email address composed of the first_name and last_name joined with a '.'. Some
+     *     examples are:
+     *     <ul>
+     *         <li>(template) {@link #firstName()}.{@link #lastName()}</li>
+     *         <li>jim.o'brian</li>
+     *         <li>jason.leigh</li>
+     *         <li>tracy.jordan</li>
+     *     </ul>
+     * </p>
+     * @return a random two part local part of an email address.
+     * @see Name#firstName()
+     * @see Name#lastName()
+     */
+    public String localPart() {
+
+        String username = StringUtils.join(
+            firstName().toLowerCase(),
+            ".",
+            lastName().toLowerCase()
+        );
+
+        return StringUtils.deleteWhitespace(username);
+    }
     
     /**
      * <p>Returns a blood group such as O−, O+, A-, A+, B-, B+, AB-, AB+</p>

--- a/src/test/java/com/github/javafaker/NameTest.java
+++ b/src/test/java/com/github/javafaker/NameTest.java
@@ -74,7 +74,20 @@ public class NameTest  extends AbstractFakerTest{
         doReturn(name).when(faker).name();
         assertThat(faker.name().username(), matchesRegularExpression("^(\\w+)\\.(\\w+)$"));
     }
-    
+
+    @Test
+    public void testLocalPart() {
+        assertThat(faker.name().localPart(), matchesRegularExpression("^([\\w']+)\\.([\\w']+)$"));
+    }
+
+    @Test
+    public void testLocalPartWithSpaces() {
+        final Name name = spy(new Name(faker));
+        doReturn("Compound Name").when(name).firstName();
+        doReturn(name).when(faker).name();
+        assertThat(faker.name().localPart(), matchesRegularExpression("^([\\w']+)\\.([\\w']+)$"));
+    }
+
     @Test
     public void testBloodGroup() {
         assertThat(faker.name().bloodGroup(), matchesRegularExpression("(A|B|AB|O)[+-]"));


### PR DESCRIPTION
Problem: Some email addresses contain single quote characters. I'd like to test that my software can handle them properly.

Solution: Include the single quotes in the email addresses generated by `faker.internet().emailAddress()`