### PR TITLE
Make sure that padding is used in Crypto

### DIFF
--- a/src/main/java/com/github/javafaker/Crypto.java
+++ b/src/main/java/com/github/javafaker/Crypto.java
@@ -12,27 +12,27 @@ public class Crypto {
     }
 
     public String md5() {
-        return generateString("MD5");
+        return generateString("MD5", "%032x");
     }
 
     public String sha1() {
-        return generateString("SHA-1");
+        return generateString("SHA-1", "%040x");
     }
 
     public String sha256() {
-        return generateString("SHA-256");
+        return generateString("SHA-256", "%064x");
     }
 
     public String sha512() {
-        return generateString("SHA-512");
+        return generateString("SHA-512", "%0128x");
     }
 
-    private String generateString(String algorithm) {
+    private String generateString(String algorithm, String format) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
             String characters = faker.lorem().characters();
             messageDigest.update(characters.getBytes(), 0, characters.length());
-            return new BigInteger(1, messageDigest.digest()).toString(16);
+            return String.format(format, new BigInteger(1, messageDigest.digest()));
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
             throw new RuntimeException(noSuchAlgorithmException);
         }

--- a/src/test/java/com/github/javafaker/CryptoTest.java
+++ b/src/test/java/com/github/javafaker/CryptoTest.java
@@ -10,21 +10,21 @@ public class CryptoTest extends AbstractFakerTest {
 
     @Test
     public void testMd5() {
-        assertThat(faker.crypto().md5(), matchesRegularExpression("[a-z\\d]+"));
+        assertThat(faker.crypto().md5(), matchesRegularExpression("\\b[a-fA-F\\d]{32}\\b"));
     }
 
     @Test
     public void testSha1() {
-        assertThat(faker.crypto().sha1(), matchesRegularExpression("[a-z\\d]+"));
+        assertThat(faker.crypto().sha1(), matchesRegularExpression("\\b[a-fA-F\\d]{40}\\b"));
     }
 
     @Test
     public void testSha256() {
-        assertThat(faker.crypto().sha256(), matchesRegularExpression("[a-z\\d]+"));
+        assertThat(faker.crypto().sha256(), matchesRegularExpression("\\b[a-fA-F\\d]{64}\\b"));
     }
 
     @Test
     public void testSha512() {
-        assertThat(faker.crypto().sha512(), matchesRegularExpression("[a-z\\d]+"));
+        assertThat(faker.crypto().sha512(), matchesRegularExpression("\\b[a-fA-F\\d]{128}\\b"));
     }
 }


### PR DESCRIPTION
In some cases it's possible to have MD5 hash (and possibly other as well) with the first byte set to 0. In this case it gets removed, while converting to BigInteger and the hex string has 31 characters. To make sure that it works as expected, we need to guarantee proper padding.