### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>1.32</version>
             <classifier>android</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.26
- [CVE-2022-25857](https://www.oscs1024.com/hd/CVE-2022-25857)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.26 to 1.32 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS