### PR TITLE
由于snakeyaml版本较低，和jackson-databind一起用会报错Could not find snakeyaml-2.0-a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,13 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>
         </dependency>
+
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
-            <classifier>android</classifier>
+            <version>2.0</version>
         </dependency>
+
         <dependency>
             <groupId>com.github.mifmif</groupId>
             <artifactId>generex</artifactId>


### PR DESCRIPTION
Could not find snakeyaml-2.0-android.jar (org.yaml:snakeyaml:2.0).
Searched in the following locations:
    https://maven.aliyun.com/repository/public/org/yaml/snakeyaml/2.0/snakeyaml-2.0-android.jar

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html

