### PR TITLE
Fix #767: NPE for IBAN with country code

### DIFF
--- a/src/main/java/com/github/javafaker/Finance.java
+++ b/src/main/java/com/github/javafaker/Finance.java
@@ -3,10 +3,7 @@ package com.github.javafaker;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Finance {
     private final Faker faker;
@@ -64,6 +61,11 @@ public class Finance {
         String basicBankAccountNumber = faker.regexify(countryCodeToBasicBankAccountNumberPattern.get(countryCode));
         String checkSum = calculateIbanChecksum(countryCode, basicBankAccountNumber);
         return countryCode + checkSum + basicBankAccountNumber;
+    }
+
+    /** Get the set of country codes supported for IBAN generation */
+    public Set<String> ibanCountryCodes() {
+        return countryCodeToBasicBankAccountNumberPattern.keySet();
     }
 
     private CreditCardType randomCreditCardType() {

--- a/src/test/java/com/github/javafaker/FinanceTest.java
+++ b/src/test/java/com/github/javafaker/FinanceTest.java
@@ -3,8 +3,10 @@ package com.github.javafaker;
 import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
 import org.junit.Test;
 
+import java.util.Set;
+
 import static com.github.javafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class FinanceTest extends AbstractFakerTest {
@@ -34,6 +36,19 @@ public class FinanceTest extends AbstractFakerTest {
 
     @Test
     public void ibanWithCountryCode() {
+        assertThat(faker.finance().iban("DE"), matchesRegularExpression("DE\\d{20}"));
+    }
+
+    @Test
+    public void ibanWithAllCountryCodes() {
+        Set<String> ibanCountryCodes = faker.finance().ibanCountryCodes();
+        for (String countryCode : ibanCountryCodes) {
+            assertThat(
+                    "IBAN for " + countryCode + " must not be null or empty",
+                    faker.finance().iban(countryCode),
+                    not(isEmptyString())
+            );
+        }
         assertThat(faker.finance().iban("DE"), matchesRegularExpression("DE\\d{20}"));
     }
 


### PR DESCRIPTION
Fixes #767

There is no easy way to control target country randomization when creating IBANs, because both  `countryCodeToBasicBankAccountNumberPattern` and `createCountryCodeToBasicBankAccountNumberPatternMap()` are private.

This PR adds a `Finance.ibanCountryCodes()` to allow finer control of scope.