### PR TITLE
CVE-2022-25857 - org.yaml.snakeyaml@1.23 vulnerable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>1.31</version>
             <classifier>android</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
Vulnerable module introduce through: org.yaml.snakeyaml@1.23
Affected version of this package are vulnerable to Denial of Service (Dos) due to missing nested depth limitation for collections.

Note: This vulnerability has also been identified as CVE-2022-25857

Remediation:
Upgrade org.yaml:snakeyaml to version 1.31 or higher