### PR TITLE
Add Fake Bitcoin Address and Transaction Hash Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Fakers
 * Witcher
 * Yoda
 * Zelda
+* Bitcoin
 
 Usage with Locales
 -----

--- a/src/main/java/com/github/javafaker/Bitcoin.java
+++ b/src/main/java/com/github/javafaker/Bitcoin.java
@@ -9,23 +9,24 @@ import java.util.Map;
 import java.util.Random;
 
 public class Bitcoin {
-    private static final String ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    private static final int BASE = ALPHABET.length();
 
-    private static final Map<String, Integer> PROTOCOL_VERSIONS = new HashMap<String, Integer>() {{
+    private final String ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    private final int BASE = ALPHABET.length();
+
+    private final Map<String, Integer> PROTOCOL_VERSIONS = new HashMap<String, Integer>() {{
         put("main", 0);
         put("testnet", 111);
     }};
 
-    public static String address() {
+    public String address() {
         return addressFor("main");
     }
 
-    public static String testnetAddress() {
+    public String testnetAddress() {
         return addressFor("testnet");
     }
 
-    public static String generateTransactionHash() {
+    public String generateTransactionHash() {
         try {
             byte[] randomData = new byte[32];
             SecureRandom random = new SecureRandom();
@@ -47,7 +48,7 @@ public class Bitcoin {
         }
     }
 
-    private static String addressFor(String network) {
+    private String addressFor(String network) {
         Integer version = PROTOCOL_VERSIONS.get(network);
         if (version == null) {
             throw new IllegalArgumentException("Invalid network specified");
@@ -70,7 +71,7 @@ public class Bitcoin {
         return encodeBase58(fullAddress);
     }
 
-    private static byte[] calculateChecksum(byte[] data) {
+    private byte[] calculateChecksum(byte[] data) {
 
         try {
             MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
@@ -84,7 +85,7 @@ public class Bitcoin {
         }
     }
 
-    private static String encodeBase58(byte[] input) {
+    private String encodeBase58(byte[] input) {
         java.math.BigInteger lv = java.math.BigInteger.ZERO;
         for (int i = 0; i < input.length; i++) {
             int value = input[input.length - 1 - i] & 0xFF;

--- a/src/main/java/com/github/javafaker/Bitcoin.java
+++ b/src/main/java/com/github/javafaker/Bitcoin.java
@@ -1,0 +1,108 @@
+package com.github.javafaker;
+
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class Bitcoin {
+    private static final String ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    private static final int BASE = ALPHABET.length();
+
+    private static final Map<String, Integer> PROTOCOL_VERSIONS = new HashMap<String, Integer>() {{
+        put("main", 0);
+        put("testnet", 111);
+    }};
+
+    public static String address() {
+        return addressFor("main");
+    }
+
+    public static String testnetAddress() {
+        return addressFor("testnet");
+    }
+
+    public static String generateTransactionHash() {
+        try {
+            byte[] randomData = new byte[32];
+            SecureRandom random = new SecureRandom();
+            random.nextBytes(randomData);
+
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(randomData);
+
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    private static String addressFor(String network) {
+        Integer version = PROTOCOL_VERSIONS.get(network);
+        if (version == null) {
+            throw new IllegalArgumentException("Invalid network specified");
+        }
+
+        byte[] addressBytes = new byte[21];
+        addressBytes[0] = version.byteValue();
+
+        Random random = new Random();
+        byte[] randomBytes = new byte[20];
+        random.nextBytes(randomBytes);
+        System.arraycopy(randomBytes, 0, addressBytes, 1, 20);
+
+        byte[] checksum = calculateChecksum(addressBytes);
+
+        byte[] fullAddress = new byte[25];
+        System.arraycopy(addressBytes, 0, fullAddress, 0, 21);
+        System.arraycopy(checksum, 0, fullAddress, 21, 4);
+
+        return encodeBase58(fullAddress);
+    }
+
+    private static byte[] calculateChecksum(byte[] data) {
+
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            byte[] hash1 = sha256.digest(data);
+            byte[] hash2 = sha256.digest(hash1);
+            byte[] checksum = new byte[4];
+            System.arraycopy(hash2, 0, checksum, 0, 4);
+            return checksum;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+        }
+    }
+
+    private static String encodeBase58(byte[] input) {
+        java.math.BigInteger lv = java.math.BigInteger.ZERO;
+        for (int i = 0; i < input.length; i++) {
+            int value = input[input.length - 1 - i] & 0xFF;
+            lv = lv.add(java.math.BigInteger.valueOf(value).multiply(java.math.BigInteger.valueOf(256).pow(i)));
+        }
+
+        StringBuilder ret = new StringBuilder();
+        while (lv.compareTo(java.math.BigInteger.ZERO) > 0) {
+            java.math.BigInteger[] divmod = lv.divideAndRemainder(java.math.BigInteger.valueOf(BASE));
+            lv = divmod[0];
+            int mod = divmod[1].intValue();
+            ret.append(ALPHABET.charAt(mod));
+        }
+
+        for (int i = 0; i < input.length && input[i] == 0; i++) {
+            ret.append(ALPHABET.charAt(0));
+        }
+
+        return ret.reverse().toString();
+    }
+}

--- a/src/main/java/com/github/javafaker/Faker.java
+++ b/src/main/java/com/github/javafaker/Faker.java
@@ -107,6 +107,7 @@ public class Faker {
     private final Sip sip;
     private final EnglandFootBall englandfootball;
     private final Mountain mountain;
+    private final Bitcoin bitcoin;
 
     public Faker() {
         this(Locale.ENGLISH);
@@ -223,6 +224,8 @@ public class Faker {
         this.sip = new Sip(this);
         this.englandfootball = new EnglandFootBall(this);
         this.mountain = new Mountain(this);
+        this.bitcoin = new Bitcoin();
+
     }
 
     /**
@@ -690,6 +693,8 @@ public class Faker {
     public EnglandFootBall englandfootball() { return englandfootball; }
 
     public Mountain mountain() { return mountain; }
+
+    public Bitcoin bitcoin() { return bitcoin; }
 
     public String resolve(String key) {
         return this.fakeValuesService.resolve(key, this, this);

--- a/src/test/java/com/github/javafaker/BitcoinTest.java
+++ b/src/test/java/com/github/javafaker/BitcoinTest.java
@@ -1,0 +1,33 @@
+package com.github.javafaker;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BitcoinTest extends AbstractFakerTest {
+
+    @Test
+    public void testMainnetAddressGeneration() {
+        String address = Bitcoin.address();
+        assertNotNull("Address should not be null.", address);
+        assertFalse("Address should not be empty.", address.isEmpty());
+        assertTrue("Address should start with '1' or '3'.", address.startsWith("1") || address.startsWith("3"));
+    }
+
+    @Test
+    public void testTestnetAddressGeneration() {
+        String address = Bitcoin.testnetAddress();
+        assertNotNull("Address should not be null.", address);
+        assertFalse("Address should not be empty.", address.isEmpty());
+        assertTrue("Address should start with 'm' or 'n'.", address.startsWith("m") || address.startsWith("n"));
+    }
+
+    @Test
+    public void testGenerateTransactionHash() {
+        String transactionHash = Bitcoin.generateTransactionHash();
+        assertNotNull("Transaction hash should not be null.", transactionHash);
+        assertEquals("Transaction hash should be 64 characters long.", 64, transactionHash.length());
+        assertTrue("Transaction hash should contain only hexadecimal characters.", transactionHash.matches("^[0-9a-fA-F]+$"));
+    }
+
+}

--- a/src/test/java/com/github/javafaker/BitcoinTest.java
+++ b/src/test/java/com/github/javafaker/BitcoinTest.java
@@ -12,6 +12,8 @@ public class BitcoinTest extends AbstractFakerTest {
         assertNotNull("Address should not be null.", address);
         assertFalse("Address should not be empty.", address.isEmpty());
         assertTrue("Address should start with '1' or '3'.", address.startsWith("1") || address.startsWith("3"));
+        assertTrue("Address length should be between 26 and 35 characters.",
+                address.length() >= 26 && address.length() <= 35);
     }
 
     @Test
@@ -20,6 +22,8 @@ public class BitcoinTest extends AbstractFakerTest {
         assertNotNull("Address should not be null.", address);
         assertFalse("Address should not be empty.", address.isEmpty());
         assertTrue("Address should start with 'm' or 'n'.", address.startsWith("m") || address.startsWith("n"));
+        assertTrue("Address length should be between 26 and 35 characters.",
+                address.length() >= 26 && address.length() <= 35);
     }
 
     @Test

--- a/src/test/java/com/github/javafaker/BitcoinTest.java
+++ b/src/test/java/com/github/javafaker/BitcoinTest.java
@@ -8,7 +8,7 @@ public class BitcoinTest extends AbstractFakerTest {
 
     @Test
     public void testMainnetAddressGeneration() {
-        String address = Bitcoin.address();
+        String address = faker.bitcoin().address();
         assertNotNull("Address should not be null.", address);
         assertFalse("Address should not be empty.", address.isEmpty());
         assertTrue("Address should start with '1' or '3'.", address.startsWith("1") || address.startsWith("3"));
@@ -18,7 +18,7 @@ public class BitcoinTest extends AbstractFakerTest {
 
     @Test
     public void testTestnetAddressGeneration() {
-        String address = Bitcoin.testnetAddress();
+        String address = faker.bitcoin().testnetAddress();
         assertNotNull("Address should not be null.", address);
         assertFalse("Address should not be empty.", address.isEmpty());
         assertTrue("Address should start with 'm' or 'n'.", address.startsWith("m") || address.startsWith("n"));
@@ -28,7 +28,7 @@ public class BitcoinTest extends AbstractFakerTest {
 
     @Test
     public void testGenerateTransactionHash() {
-        String transactionHash = Bitcoin.generateTransactionHash();
+        String transactionHash = faker.bitcoin().generateTransactionHash();
         assertNotNull("Transaction hash should not be null.", transactionHash);
         assertEquals("Transaction hash should be 64 characters long.", 64, transactionHash.length());
         assertTrue("Transaction hash should contain only hexadecimal characters.", transactionHash.matches("^[0-9a-fA-F]+$"));


### PR DESCRIPTION
### Add Fake Bitcoin Address and Transaction Hash Generation

#### Description

This pull request adds support for generating fake Bitcoin addresses and transaction hashes within the Java Faker library. It includes:

- **Bitcoin Address Generation:**
  - Implemented methods to generate fake Bitcoin addresses for the **main network** (`address()`) and the **test network** (`testnetAddress()`).
  - Addresses are generated using **Base58Check encoding** with network-specific version bytes (0 for mainnet, 111 for testnet), following Bitcoin's address format conventions.
  - For more details on these version bytes and their corresponding address prefixes, refer to the [Bitcoin Wiki - List of address prefixes](https://en.bitcoin.it/wiki/List_of_address_prefixes).

- **Transaction Hash Generation:**
  - Added a method (`generateTransactionHash()`) to create random 64-character hexadecimal strings simulating Bitcoin transaction hashes.
  - The method uses SHA-256 hashing for generating the transaction hash format.

#### Motivation
This addition allows Java Faker to generate realistic data related to Bitcoin transactions, enhancing the library’s utility for testing cryptocurrency-related applications.

#### Testing
- Added unit tests to verify:
  - Correct format and prefix of mainnet and testnet addresses.
  - Address length within the expected range (26 to 35 characters).
  - Validity of generated transaction hashes as 64-character hexadecimal strings.

#### Notes
Please let me know if any adjustments are needed, or if further tests and documentation updates are required.
